### PR TITLE
Use CSV input to create multiple AD users

### DIFF
--- a/New Users/NewUserOrCopy_FromCSV.ps1
+++ b/New Users/NewUserOrCopy_FromCSV.ps1
@@ -1,147 +1,120 @@
 # Requires: ActiveDirectory module
 
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$CsvPath
+)
+
 Import-Module ActiveDirectory
 
-function Read-Required {
-    param(
-        [string]$Prompt
-    )
-    do {
-        $value = Read-Host $Prompt
-    } while ([string]::IsNullOrWhiteSpace($value))
-    return $value
+function Test-PasswordComplexity {
+    param([string]$Plain)
+    $Plain.Length -ge 12 -and
+    $Plain -match '[A-Z]' -and
+    $Plain -match '[a-z]' -and
+    $Plain -match '[0-9]' -and
+    $Plain -match '[^a-zA-Z0-9]'
 }
 
-function Prompt-UserInfo {
-    do {
-        $givenName = Read-Required "First name"
-        $surname = Read-Required "Last name"
-        $nameExists = Get-ADUser -Filter "GivenName -eq '$givenName' -and Surname -eq '$surname'" -ErrorAction SilentlyContinue
-        if ($nameExists) { Write-Warning "A user with that first and last name already exists." }
-    } while ($nameExists)
+$records = Import-Csv -Path $CsvPath
 
-    do {
-        $sam = Read-Required "Desired username"
-        $samExists = Get-ADUser -Filter "SamAccountName -eq '$sam'" -ErrorAction SilentlyContinue
-        if ($samExists) { Write-Warning "Username $sam already exists." }
-    } while ($samExists)
+foreach ($record in $records) {
+    $choice = $record.Action.ToUpper()
 
-    $title = Read-Host "Title (if desired)"
-    $department = Read-Host "Department (if desired)"
-
-    do {
-        $manager = Read-Host "Manager (sAMAccountName or DN, leave blank if none)"
-        if ($manager) {
-            $mgrExists = Get-ADUser -Identity $manager -ErrorAction SilentlyContinue
-            if (-not $mgrExists) { Write-Warning "Manager $manager not found." }
-        }
-    } while ($manager -and -not $mgrExists)
-
-    $phone = Read-Host "Phone number (if desired)"
-    $email = Read-Host "Email (if desired)"
-
-    return [pscustomobject]@{
-        GivenName     = $givenName
-        Surname       = $surname
-        SamAccountName= $sam
-        Title         = $title
-        Department    = $department
-        Manager       = $manager
-        Phone         = $phone
-        Email         = $email
+    $userInfo = [pscustomobject]@{
+        GivenName      = $record.GivenName
+        Surname        = $record.Surname
+        SamAccountName = $record.SamAccountName
+        Title          = $record.Title
+        Department     = $record.Department
+        Manager        = $record.Manager
+        Phone          = $record.Phone
+        Email          = $record.Email
     }
-}
 
-function Read-Password {
-    do {
-        $plain = Read-Host "Temporary password"
-        $complex = $plain.Length -ge 12 -and
-                   $plain -match '[A-Z]' -and
-                   $plain -match '[a-z]' -and
-                   $plain -match '[0-9]' -and
-                   $plain -match '[^a-zA-Z0-9]'
-        if (-not $complex) {
-            Write-Warning "Password must be ≥12 chars and include uppercase, lowercase, number, and symbol."
+    $nameExists = Get-ADUser -Filter "GivenName -eq '$($userInfo.GivenName)' -and Surname -eq '$($userInfo.Surname)'" -ErrorAction SilentlyContinue
+    if ($nameExists) { Write-Warning "A user with first name '$($userInfo.GivenName)' and last name '$($userInfo.Surname)' already exists. Skipping."; continue }
+
+    $samExists = Get-ADUser -Filter "SamAccountName -eq '$($userInfo.SamAccountName)'" -ErrorAction SilentlyContinue
+    if ($samExists) { Write-Warning "Username $($userInfo.SamAccountName) already exists. Skipping."; continue }
+
+    if ($userInfo.Manager) {
+        $mgrExists = Get-ADUser -Identity $userInfo.Manager -ErrorAction SilentlyContinue
+        if (-not $mgrExists) {
+            Write-Warning "Manager $($userInfo.Manager) not found. Manager will be ignored."
+            $userInfo.Manager = $null
         }
-    } until ($complex)
+    }
 
-    ConvertTo-SecureString $plain -AsPlainText -Force
-}
+    if (-not (Test-PasswordComplexity $record.Password)) {
+        Write-Warning "Password for $($userInfo.SamAccountName) must be ≥12 chars and include uppercase, lowercase, number, and symbol. Skipping."
+        continue
+    }
 
-$choice = ""
-while ($choice -notin @('N','C')) {
-    $choice = Read-Host "Is this a (N)ew user or (C)opy from existing user? (N/C)"
-    $choice = $choice.ToUpper()
-}
+    $password = ConvertTo-SecureString $record.Password -AsPlainText -Force
 
-$userInfo = Prompt-UserInfo
-$password = Read-Password
-
-if ($choice -eq 'N') {
-    do {
-        $ou = Read-Required "OU distinguished name to create user in (e.g., OU=Employees,DC=example,DC=com)"
+    if ($choice -eq 'N') {
+        $ou = $record.OU
         $ouExists = Get-ADOrganizationalUnit -Identity $ou -ErrorAction SilentlyContinue
-        if (-not $ouExists) { Write-Warning "OU $ou not found." }
-    } while (-not $ouExists)
+        if (-not $ouExists) { Write-Warning "OU $ou not found. Skipping $($userInfo.SamAccountName)."; continue }
 
-    $refUser = Get-ADUser -Filter * -SearchBase $ou ` | Select-Object -First 1
-    $defaultDomain = $refUser.UserPrincipalName.Split('@')[1]
-    $domainInput = Read-Host "UPN domain (leave blank for $defaultDomain)"
-    if ([string]::IsNullOrWhiteSpace($domainInput)) {
-        $domain = $defaultDomain
-    } else {
-        $domain = $domainInput
-    }
-    $userParams = @{
-        GivenName             = $userInfo.GivenName
-        Surname               = $userInfo.Surname
-        Name                  = "$($userInfo.GivenName) $($userInfo.Surname)"
-        SamAccountName        = $userInfo.SamAccountName
-        UserPrincipalName     = "$($userInfo.SamAccountName)@$domain"
-        Path                  = $ou
-        AccountPassword       = $password
-        ChangePasswordAtLogon = $true
-        Enabled               = $true
-    }
+        $refUser = Get-ADUser -Filter * -SearchBase $ou | Select-Object -First 1
+        $defaultDomain = $refUser.UserPrincipalName.Split('@')[1]
+        $domain = if ([string]::IsNullOrWhiteSpace($record.Domain)) { $defaultDomain } else { $record.Domain }
 
-    if ($userInfo.Title)      { $userParams['Title']        = $userInfo.Title }
-    if ($userInfo.Department) { $userParams['Department']   = $userInfo.Department }
-    if ($userInfo.Manager)    { $userParams['Manager']      = $userInfo.Manager }
-    if ($userInfo.Phone)      { $userParams['OfficePhone']  = $userInfo.Phone }
-    if ($userInfo.Email)      { $userParams['EmailAddress'] = $userInfo.Email }
-    
-    New-ADUser @userParams
-    Write-Host "Created user $($userInfo.SamAccountName) in $ou"
-} else {
-    $sourceUser = $null
-    do {
-        $sourceSam = Read-Required "Enter the username to copy from"
+        $userParams = @{
+            GivenName             = $userInfo.GivenName
+            Surname               = $userInfo.Surname
+            Name                  = "$($userInfo.GivenName) $($userInfo.Surname)"
+            SamAccountName        = $userInfo.SamAccountName
+            UserPrincipalName     = "$($userInfo.SamAccountName)@$domain"
+            Path                  = $ou
+            AccountPassword       = $password
+            ChangePasswordAtLogon = $true
+            Enabled               = $true
+        }
+
+        if ($userInfo.Title)      { $userParams['Title']        = $userInfo.Title }
+        if ($userInfo.Department) { $userParams['Department']   = $userInfo.Department }
+        if ($userInfo.Manager)    { $userParams['Manager']      = $userInfo.Manager }
+        if ($userInfo.Phone)      { $userParams['OfficePhone']  = $userInfo.Phone }
+        if ($userInfo.Email)      { $userParams['EmailAddress'] = $userInfo.Email }
+
+        New-ADUser @userParams
+        Write-Host "Created user $($userInfo.SamAccountName) in $ou"
+    }
+    elseif ($choice -eq 'C') {
+        $sourceSam = $record.SourceSam
         $sourceUser = Get-ADUser -Identity $sourceSam -Properties MemberOf,Title,Manager,OfficePhone,EmailAddress -ErrorAction SilentlyContinue
-        if (-not $sourceUser) { Write-Warning "Source user $sourceSam not found." }
-    } while (-not $sourceUser)
+        if (-not $sourceUser) { Write-Warning "Source user $sourceSam not found. Skipping $($userInfo.SamAccountName)."; continue }
 
-    $domain = $sourceUser.UserPrincipalName.Split('@')[1]
-    $ou = $sourceUser.DistinguishedName -replace '^CN=[^,]+,',''
-    $userParams = @{
-        GivenName             = $userInfo.GivenName
-        Surname               = $userInfo.Surname
-        Name                  = "$($userInfo.GivenName) $($userInfo.Surname)"
-        SamAccountName        = $userInfo.SamAccountName
-        UserPrincipalName     = "$($userInfo.SamAccountName)@$domain"
-        Path                  = $ou
-        AccountPassword       = $password
-        ChangePasswordAtLogon = $true
-        Enabled               = $true
+        $domain = $sourceUser.UserPrincipalName.Split('@')[1]
+        $ou = $sourceUser.DistinguishedName -replace '^CN=[^,]+,',''
+
+        $userParams = @{
+            GivenName             = $userInfo.GivenName
+            Surname               = $userInfo.Surname
+            Name                  = "$($userInfo.GivenName) $($userInfo.Surname)"
+            SamAccountName        = $userInfo.SamAccountName
+            UserPrincipalName     = "$($userInfo.SamAccountName)@$domain"
+            Path                  = $ou
+            AccountPassword       = $password
+            ChangePasswordAtLogon = $true
+            Enabled               = $true
+        }
+
+        if ($userInfo.Title)      { $userParams['Title']        = $userInfo.Title }
+        if ($userInfo.Department) { $userParams['Department']   = $userInfo.Department }
+        if ($userInfo.Manager)    { $userParams['Manager']      = $userInfo.Manager } elseif ($sourceUser.Manager) { $userParams['Manager'] = $sourceUser.Manager }
+        if ($userInfo.Phone)      { $userParams['OfficePhone']  = $userInfo.Phone }
+        if ($userInfo.Email)      { $userParams['EmailAddress'] = $userInfo.Email }
+
+        New-ADUser @userParams
+        $groups = $sourceUser.MemberOf
+        if ($groups) { Add-ADPrincipalGroupMembership -Identity $userInfo.SamAccountName -MemberOf $groups }
+        Write-Host "Created user $($userInfo.SamAccountName) copied from $sourceSam in $ou"
     }
-
-    if ($userInfo.Title)      { $userParams['Title']        = $userInfo.Title }
-    if ($userInfo.Department) { $userParams['Department']   = $userInfo.Department }
-    if ($userInfo.Manager)    { $userParams['Manager']      = $userInfo.Manager } elseif ($sourceUser.Manager) { $userParams['Manager'] = $sourceUser.Manager }
-    if ($userInfo.Phone)      { $userParams['OfficePhone']  = $userInfo.Phone }
-    if ($userInfo.Email)      { $userParams['EmailAddress'] = $userInfo.Email }
-    
-    New-ADUser @userParams
-    $groups = $sourceUser.MemberOf
-    if ($groups) { Add-ADPrincipalGroupMembership -Identity $userInfo.SamAccountName -MemberOf $groups }
-    Write-Host "Created user $($userInfo.SamAccountName) copied from $sourceSam  in $ou"
+    else {
+        Write-Warning "Invalid action '$choice' for $($userInfo.SamAccountName). Use 'N' for new or 'C' for copy."
+    }
 }


### PR DESCRIPTION
## Summary
- allow NewUserOrCopy_FromCSV.ps1 to read user details from a CSV
- iterate through each record to create or copy Active Directory users
- validate each password and skip records that fail complexity requirements

## Testing
- `pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path 'New Users/NewUserOrCopy_FromCSV.ps1'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e74eef64833083599a6f2ab0868e