### PR TITLE
Show only mapped drives in ManageCurrentUserMappings script

### DIFF
--- a/windows/network/ManageCurrentUserMappings.ps1
+++ b/windows/network/ManageCurrentUserMappings.ps1
@@ -1,10 +1,9 @@
 <#
 .SYNOPSIS
-    Manages mapped drives for the current user and displays current-user printer mappings.
+    Manages mapped drives for the current user.
 .DESCRIPTION
-    Resolves current user SID from loaded HKEY_USERS and presents a menu to view mappings, add mapped drives (manual or
-    CSV), remove mapped drives (selection or CSV), or exit. Also displays current-user HKU printer connection entries
-    for context. CSV paths are prompted and must be under C:\Temp.
+    Resolves current user SID from loaded HKEY_USERS and presents a menu to view drive mappings, add mapped drives
+    (manual or CSV), remove mapped drives (selection or CSV), or exit. CSV paths are prompted and must be under C:\Temp.
 #>
 
 Set-StrictMode -Version Latest
@@ -149,28 +148,9 @@ function Get-MappedDrivesForSid {
     })
 }
 
-function Get-PrinterMappingsForSid {
-    param(
-        [Parameter(Mandatory)]
-        [string]$Sid
-    )
-
-    $printerPath = "Registry::HKEY_USERS\$Sid\Printers\Connections"
-    if (-not (Test-Path -LiteralPath $printerPath)) {
-        return @()
-    }
-
-    return @(Get-ChildItem -LiteralPath $printerPath -ErrorAction SilentlyContinue | ForEach-Object {
-        [pscustomobject]@{
-            ConnectionName = $_.PSChildName
-        }
-    })
-}
-
 function Show-CurrentMappings {
     param(
-        [object[]]$Drives = @(),
-        [object[]]$Printers = @()
+        [object[]]$Drives = @()
     )
 
     Write-Host ''
@@ -185,16 +165,6 @@ function Show-CurrentMappings {
         }
     }
 
-    Write-Host ''
-    Write-Host 'Mapped Printer Connections:' -ForegroundColor Green
-    if ($Printers.Count -eq 0) {
-        Write-Host '  (none found)' -ForegroundColor DarkYellow
-    }
-    else {
-        foreach ($p in $Printers) {
-            Write-Host "  $($p.ConnectionName)"
-        }
-    }
 }
 
 function Add-MappedDrive {
@@ -345,8 +315,7 @@ function Invoke-Main {
 
     while ($true) {
         $drives = @(Get-MappedDrivesForSid -Sid $context.Sid)
-        $printers = @(Get-PrinterMappingsForSid -Sid $context.Sid)
-        Show-CurrentMappings -Drives $drives -Printers $printers
+        Show-CurrentMappings -Drives $drives
 
         Write-Host ''
         Write-Host 'Actions:' -ForegroundColor Yellow

--- a/windows/network/Readme.md
+++ b/windows/network/Readme.md
@@ -54,13 +54,12 @@ This folder contains technician scripts for subnet reachability scanning and cur
 
 ## ManageCurrentUserMappings.ps1
 
-**Purpose:** Current-user mapping manager for drive mappings with context display of printer mappings. Resolves current user SID from loaded hives, shows mapped drives/printers, then provides actions to add/remove mapped drives or exit.
+**Purpose:** Current-user mapping manager for drive mappings. Resolves current user SID from loaded hives, shows mapped drives, then provides actions to add/remove mapped drives or exit.
 
 **Safety / impact:**
 
 - **Destructive actions exist** for mapped drives (add/remove drive mappings).
 - Scope is **current loaded user context** only; no multi-user operation.
-- Printer entries are displayed for context and are not changed by this script.
 
 **Execution context:** Elevated technician/admin session is recommended for reliable context resolution and mapping visibility.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove printer mapping retrieval from `ManageCurrentUserMappings.ps1`
- update `Show-CurrentMappings` to accept and display only drive mappings
- update script synopsis/description to reflect drive-only display behavior
- update `windows/network/Readme.md` to document drive-only behavior for `ManageCurrentUserMappings.ps1`

## Testing
- not run (PowerShell script and README changes only; no automated tests in repo for this script)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be7c6bbf-7b51-4bcb-b735-ceb1e03f5d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be7c6bbf-7b51-4bcb-b735-ceb1e03f5d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

