### PR TITLE
Fix Count access in TargetFolderSizeDrilldown recursion

### DIFF
--- a/windows/disk/TargetFolderSizeDrilldown.ps1
+++ b/windows/disk/TargetFolderSizeDrilldown.ps1
@@ -39,11 +39,11 @@ function Show-FolderTree {
     )
 
     $indent = '  ' * $Depth
-    $subFolders = Get-ChildItem -Path $Path -Directory -Force -ErrorAction SilentlyContinue
+    $subFolders = @(Get-ChildItem -Path $Path -Directory -Force -ErrorAction SilentlyContinue)
 
     if (-not $subFolders) { return }
 
-    $children = foreach ($folder in $subFolders) {
+    $children = @(foreach ($folder in $subFolders) {
         Write-Progress-Line "[Scanning] $($folder.FullName)"
         $sizeBytes = Get-FolderSize -Path $folder.FullName
         $sizeGB = [Math]::Round($sizeBytes / 1GB, 2)
@@ -58,7 +58,7 @@ function Show-FolderTree {
             SizeGB      = $sizeGB
             PctOfParent = $pct
         }
-    }
+    })
 
     Clear-Progress-Line
 
@@ -66,7 +66,7 @@ function Show-FolderTree {
         ($children | Measure-Object -Property PctOfParent -Average).Average
     } else { 0 }
 
-    $qualifies = foreach ($c in $children) {
+    $qualifies = @(foreach ($c in $children) {
         $gap = $c.PctOfParent - $avgPct
         $meetsSize = $c.SizeGB -gt $script:SizeThresholdGB
         $meetsDominance = $gap -gt $script:DominanceGap
@@ -75,9 +75,9 @@ function Show-FolderTree {
             Gap          = [Math]::Round($gap, 2)
             ShouldExpand = ($meetsSize -and $meetsDominance)
         }
-    }
+    })
 
-    $toExpand = $qualifies | Where-Object { $_.ShouldExpand }
+    $toExpand = @($qualifies | Where-Object { $_.ShouldExpand })
 
     if ($toExpand) {
         $expandNames = ($toExpand | ForEach-Object {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix `TargetFolderSizeDrilldown.ps1` to handle single-item pipeline results safely under `Set-StrictMode -Version Latest`
- wrap subfolder and derived scan collections in array subexpressions so `.Count` is always valid
- prevent recursion status output from throwing when only one child folder qualifies

## Testing
- runtime PowerShell execution was not possible in this Linux cloud environment because `pwsh` is not installed
- verified the change is limited to collection materialization in `Show-FolderTree` and does not alter the expansion criteria logic
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f78d11a2-dcb2-4be4-89d1-c553185855a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f78d11a2-dcb2-4be4-89d1-c553185855a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

