### PR TITLE
Move SetPageFile tests to data/tests/

### DIFF
--- a/data/tests/SetPageFile.Tests.ps1
+++ b/data/tests/SetPageFile.Tests.ps1
@@ -20,9 +20,9 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 BeforeAll {
-    # Test file lives in <repo>/tests, the script under test lives in
-    # <repo>/windows/disk/SetPageFile.ps1.
-    $script:ScriptPath = Join-Path $PSScriptRoot '..' 'windows' 'disk' 'SetPageFile.ps1'
+    # Test file lives in <repo>/data/tests, the script under test lives
+    # in <repo>/windows/disk/SetPageFile.ps1.
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' '..' 'windows' 'disk' 'SetPageFile.ps1'
     if (-not (Test-Path -LiteralPath $script:ScriptPath)) {
         throw "SetPageFile.ps1 not found at expected path: $script:ScriptPath"
     }

--- a/tests/SetPageFile.Tests.ps1
+++ b/tests/SetPageFile.Tests.ps1
@@ -20,10 +20,13 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 BeforeAll {
-    $script:ScriptPath = Join-Path $PSScriptRoot 'SetPageFile.ps1'
+    # Test file lives in <repo>/tests, the script under test lives in
+    # <repo>/windows/disk/SetPageFile.ps1.
+    $script:ScriptPath = Join-Path $PSScriptRoot '..' 'windows' 'disk' 'SetPageFile.ps1'
     if (-not (Test-Path -LiteralPath $script:ScriptPath)) {
-        throw "SetPageFile.ps1 not found next to test file at: $script:ScriptPath"
+        throw "SetPageFile.ps1 not found at expected path: $script:ScriptPath"
     }
+    $script:ScriptPath = (Resolve-Path -LiteralPath $script:ScriptPath).Path
 
     # The production script ends with a top-level try { Invoke-Main } catch
     # block that auto-executes on dot-source. To load the function


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #12. Relocates `SetPageFile.Tests.ps1` from the repo-root `tests/` folder to `data/tests/`.

## Changes

- `git mv tests/SetPageFile.Tests.ps1 data/tests/SetPageFile.Tests.ps1`.
- Updated the `BeforeAll` script-path resolution from `../windows/disk/SetPageFile.ps1` to `../../windows/disk/SetPageFile.ps1` so the test continues to find the script under test from its new two-levels-deep location.

## Testing

✅ `pwsh -NoProfile -Command 'Invoke-Pester -Path ./data/tests/SetPageFile.Tests.ps1 -Output Detailed'` — 14 passed, 0 failed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a98fc986-f5ef-479b-ad89-a07eaf998fd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a98fc986-f5ef-479b-ad89-a07eaf998fd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

