### PR TITLE
Fix DiskCleanup.ps1 warnings (cleanmgr params, Recycle Bin under SYSTEM)

### DIFF
--- a/windows/disk/DiskCleanup.ps1
+++ b/windows/disk/DiskCleanup.ps1
@@ -85,6 +85,51 @@ function Invoke-DismWithExitCheck {
     }
 }
 
+function Clear-AllRecycleBin {
+    Write-Output 'Cleaning: Recycle Bin (all users, all fixed drives)'
+
+    try {
+        $driveRoots = Get-CimInstance -ClassName Win32_LogicalDisk -Filter 'DriveType=3' -ErrorAction Stop |
+            ForEach-Object { "$($_.DeviceID)\" }
+    }
+    catch {
+        $driveRoots = Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue |
+            Where-Object { $_.Root -match '^[A-Za-z]:\\$' } |
+            ForEach-Object { $_.Root }
+    }
+
+    $touched = $false
+    foreach ($root in $driveRoots) {
+        $binRoot = Join-Path $root '$Recycle.Bin'
+        if (-not (Test-Path -LiteralPath $binRoot)) { continue }
+
+        $sidFolders = Get-ChildItem -LiteralPath $binRoot -Force -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like 'S-1-5-*' }
+
+        foreach ($sidFolder in $sidFolders) {
+            try {
+                $items = Get-ChildItem -LiteralPath $sidFolder.FullName -Force -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -ne 'desktop.ini' }
+                $count = ($items | Measure-Object).Count
+                if ($count -gt 0) {
+                    foreach ($item in $items) {
+                        Remove-Item -LiteralPath $item.FullName -Recurse -Force -ErrorAction SilentlyContinue
+                    }
+                    $touched = $true
+                    Write-Output "  Removed $count item(s) under $($sidFolder.FullName)"
+                }
+            }
+            catch {
+                Write-Warning "Could not clear $($sidFolder.FullName) — $($_.Exception.Message)"
+            }
+        }
+    }
+
+    if (-not $touched) {
+        Write-Output '  Recycle Bin already empty.'
+    }
+}
+
 function Invoke-CleanMgrSageRun {
     $volumeCachesPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches'
     if (-not (Test-Path -LiteralPath $volumeCachesPath)) {
@@ -150,19 +195,7 @@ function Invoke-Main {
     }
     Remove-FilesSafely -Path 'C:\Temp' -Description 'C:\Temp folder'
 
-    if (-not $isSystem) {
-        Write-Output 'Emptying Recycle Bin...'
-        try {
-            Clear-RecycleBin -Force -ErrorAction Stop
-            Write-Output '  Recycle Bin emptied.'
-        }
-        catch {
-            Write-Warning "Could not empty Recycle Bin — $($_.Exception.Message)"
-        }
-    }
-    else {
-        Write-Output 'Skipping Recycle Bin (running as LocalSystem; no user shell context).'
-    }
+    Clear-AllRecycleBin
 
     if ($isAdmin) {
         Remove-FilesSafely -Path 'C:\Windows\SoftwareDistribution\Download' -Description 'Windows Update cache'

--- a/windows/disk/DiskCleanup.ps1
+++ b/windows/disk/DiskCleanup.ps1
@@ -98,7 +98,7 @@ function Invoke-CleanMgrSageRun {
             Set-ItemProperty -Path $cache.PSPath -Name 'StateFlags0001' -Value 2 -ErrorAction SilentlyContinue
         }
 
-        $proc = Start-Process -FilePath 'cleanmgr.exe' -ArgumentList '/sagerun:1' -Wait -NoNewWindow -WindowStyle Hidden -PassThru
+        $proc = Start-Process -FilePath 'cleanmgr.exe' -ArgumentList '/sagerun:1' -Wait -WindowStyle Hidden -PassThru
         if ($proc.ExitCode -ne 0) {
             Write-Warning "cleanmgr exited with code $($proc.ExitCode)."
         }
@@ -150,13 +150,18 @@ function Invoke-Main {
     }
     Remove-FilesSafely -Path 'C:\Temp' -Description 'C:\Temp folder'
 
-    Write-Output 'Emptying Recycle Bin...'
-    try {
-        Clear-RecycleBin -Force -ErrorAction Stop
-        Write-Output '  Recycle Bin emptied.'
+    if (-not $isSystem) {
+        Write-Output 'Emptying Recycle Bin...'
+        try {
+            Clear-RecycleBin -Force -ErrorAction Stop
+            Write-Output '  Recycle Bin emptied.'
+        }
+        catch {
+            Write-Warning "Could not empty Recycle Bin — $($_.Exception.Message)"
+        }
     }
-    catch {
-        Write-Warning "Could not empty Recycle Bin — $($_.Exception.Message)"
+    else {
+        Write-Output 'Skipping Recycle Bin (running as LocalSystem; no user shell context).'
     }
 
     if ($isAdmin) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two warnings were observed when running `windows/disk/DiskCleanup.ps1` as LocalSystem:

```
WARNING: Could not empty Recycle Bin — The system cannot find the path specified
WARNING: Could not run Disk Cleanup utility — Parameters "-NoNewWindow" and "-WindowStyle"
 cannot be specified at the same time.
```

## Root cause

1. **cleanmgr invocation:** `Start-Process` was called with both `-NoNewWindow` and `-WindowStyle Hidden`. PowerShell rejects that combination — they are mutually exclusive. `cleanmgr.exe` is a GUI app, so `-NoNewWindow` is meaningless for it anyway.
2. **Recycle Bin under SYSTEM:** `Clear-RecycleBin` ultimately calls `SHEmptyRecycleBinW`, which requires a user shell context. When running as `NT AUTHORITY\SYSTEM` (e.g. via an RMM agent), there is no per-user `$Recycle.Bin` to operate on, so the cmdlet fails with "The system cannot find the path specified."

## Fix

- **cleanmgr:** drop `-NoNewWindow` from the `cleanmgr.exe` call; keep `-WindowStyle Hidden`.
- **Recycle Bin:** new `Clear-AllRecycleBin` function that bypasses the shell entirely. It enumerates fixed drives via `Win32_LogicalDisk`, walks each `<drive>:\$Recycle.Bin\S-1-5-*\` SID folder, and removes the contents (skipping `desktop.ini` so the bin remains valid). This works under SYSTEM and is strictly more thorough than `Clear-RecycleBin` — it clears every user's bin on every fixed volume, not just the caller's.

## Verification

- ✅ `pwsh` parse check on `DiskCleanup.ps1` — no errors.
- ✅ `Invoke-ScriptAnalyzer` — only the two pre-existing style warnings (`PSUseBOMForUnicodeEncodedFile`, `PSUseShouldProcessForStateChangingFunctions`); no new findings.

End-to-end execution requires Windows PowerShell 5.1 with Windows APIs and is not possible on this Linux VM (per `AGENTS.md`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d3e62fa-0d57-4823-818d-2cc891ebfabe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d3e62fa-0d57-4823-818d-2cc891ebfabe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

