### PR TITLE
Fix PageFileSizeCheck false "does not exist" + spurious status-code error

### DIFF
--- a/windows/disk/PageFileSizeCheck.ps1
+++ b/windows/disk/PageFileSizeCheck.ps1
@@ -15,15 +15,15 @@ function Get-PagefileSizeReport {
     )
 
     if (-not (Test-Path -LiteralPath $LiteralPath -PathType Leaf)) {
-        Write-Output "File does not exist: $LiteralPath"
+        Write-Host "File does not exist: $LiteralPath"
         return
     }
 
     $item = Get-Item -LiteralPath $LiteralPath -Force -ErrorAction Stop
     $sizeBytes = $item.Length
     $sizeGB = [Math]::Round($sizeBytes / 1GB, 4)
-    Write-Output "Path: $LiteralPath"
-    Write-Output "Size: $sizeGB GB ($sizeBytes bytes)"
+    Write-Host "Path: $LiteralPath"
+    Write-Host "Size: $sizeGB GB ($sizeBytes bytes)"
 }
 
 function Invoke-Main {

--- a/windows/disk/PageFileSizeCheck.ps1
+++ b/windows/disk/PageFileSizeCheck.ps1
@@ -3,6 +3,10 @@
     Reports whether C:\pagefile.sys exists and its size on disk.
 .DESCRIPTION
     Read-only check of C:\pagefile.sys. No prompts or script parameters.
+    Queries CIM (Win32_PageFileUsage / Win32_PageFileSetting / Win32_ComputerSystem)
+    rather than Test-Path, because pagefile.sys is held with an exclusive
+    handle by the OS Memory Manager and the FileSystem provider reports it
+    as missing on access-denied.
 #>
 
 Set-StrictMode -Version Latest
@@ -14,16 +18,72 @@ function Get-PagefileSizeReport {
         [string]$LiteralPath
     )
 
-    if (-not (Test-Path -LiteralPath $LiteralPath -PathType Leaf)) {
-        Write-Host "File does not exist: $LiteralPath"
-        return
+    $reported = $false
+
+    try {
+        $usage = Get-CimInstance -ClassName Win32_PageFileUsage -ErrorAction Stop |
+            Where-Object { $_.Name -ieq $LiteralPath }
+        foreach ($u in $usage) {
+            $reported = $true
+            Write-Host "Active pagefile: $($u.Name)"
+            Write-Host "  Allocated:    $($u.AllocatedBaseSize) MB"
+            Write-Host "  Current use:  $($u.CurrentUsage) MB"
+            Write-Host "  Peak use:     $($u.PeakUsage) MB"
+        }
+    }
+    catch {
+        Write-Host "Win32_PageFileUsage query failed: $($_.Exception.Message)"
     }
 
-    $item = Get-Item -LiteralPath $LiteralPath -Force -ErrorAction Stop
-    $sizeBytes = $item.Length
-    $sizeGB = [Math]::Round($sizeBytes / 1GB, 4)
-    Write-Host "Path: $LiteralPath"
-    Write-Host "Size: $sizeGB GB ($sizeBytes bytes)"
+    try {
+        $setting = Get-CimInstance -ClassName Win32_PageFileSetting -ErrorAction Stop |
+            Where-Object { $_.Name -ieq $LiteralPath }
+        foreach ($s in $setting) {
+            Write-Host "Configured pagefile: $($s.Name)"
+            Write-Host "  Initial size: $($s.InitialSize) MB (0 = system-managed)"
+            Write-Host "  Maximum size: $($s.MaximumSize) MB (0 = system-managed)"
+            $reported = $true
+        }
+    }
+    catch {
+        Write-Host "Win32_PageFileSetting query failed: $($_.Exception.Message)"
+    }
+
+    try {
+        $cs = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
+        if ($cs.AutomaticManagedPagefile) {
+            Write-Host 'AutomaticManagedPagefile: ENABLED (size managed by Windows; may not appear in Win32_PageFileSetting).'
+        }
+        else {
+            Write-Host 'AutomaticManagedPagefile: disabled.'
+        }
+    }
+    catch {
+        Write-Host "Win32_ComputerSystem query failed: $($_.Exception.Message)"
+    }
+
+    try {
+        $fi = [System.IO.FileInfo]::new($LiteralPath)
+        if ($fi.Exists) {
+            $sizeBytes = $fi.Length
+            $sizeGB = [Math]::Round($sizeBytes / 1GB, 4)
+            Write-Host "On-disk file: $LiteralPath"
+            Write-Host "  Size: $sizeGB GB ($sizeBytes bytes)"
+            $reported = $true
+        }
+    }
+    catch {
+        # On-disk size is best-effort: pagefile.sys is held with an exclusive
+        # handle and FileInfo.Length may throw under tight ACLs even when the
+        # file exists. CIM data above is authoritative.
+        Write-Verbose "FileInfo probe failed: $($_.Exception.Message)"
+    }
+
+    if (-not $reported) {
+        Write-Host "No active or configured pagefile found at: $LiteralPath"
+        Write-Host 'Note: pagefile.sys is a locked OS file. If you expect it to exist,'
+        Write-Host 'rerun this script from an elevated (Administrator) PowerShell.'
+    }
 }
 
 function Invoke-Main {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problems

1. **False negative on existence.** `PageFileSizeCheck.ps1` reports `File does not exist: C:\pagefile.sys` on machines where the pagefile is clearly there.
2. **Spurious failure message after success.**
   ```
   [SUCCESS] PageFileSizeCheck completed.
   [ERROR] [ERROR] PageFileSizeCheck completed with status code File does not exist: C:\pagefile.sys 0.
   ```

## Root causes

### (1) False "does not exist"

`pagefile.sys` is held with an exclusive handle by the OS Memory Manager and protected by tight ACLs. `Test-Path -PathType Leaf` and `Get-Item` go through the FileSystem provider, which calls `[System.IO.File]::Exists` under the hood. That API returns `$false` on access-denied, so user-mode code (especially non-elevated) gets back a "missing file" verdict for a file that very much exists.

### (2) Spurious error wrapper

`Get-PagefileSizeReport` previously emitted its report lines via `Write-Output`. PowerShell merges all success-stream output into a function's return value, so `Invoke-Main` actually returned `@('File does not exist: C:\pagefile.sys', 0)`. The wrapper's `if ($statusCode -ne 0)` is truthy against an array (filter semantics), the error branch fired, and the array stringified space-joined into the `"... status code File does not exist: C:\pagefile.sys 0"` text.

## Fix

Stop asking the FileSystem provider about a file user-mode code can't open. Query CIM instead — these don't need to open the locked file:

- `Win32_PageFileUsage` → active pagefile path, allocated/current/peak size in MB.
- `Win32_PageFileSetting` → configured initial / maximum size (empty when system-managed).
- `Win32_ComputerSystem.AutomaticManagedPagefile` → flags the system-managed case so an empty `Win32_PageFileSetting` isn't misread as "no pagefile".

Keep a best-effort `FileInfo` probe as supplementary on-disk byte size, but don't gate the verdict on it. Only emit a "not found" message when **all** signals come up empty, and explicitly tell the operator to rerun elevated.

Also routes the report lines through `Write-Host` so only the numeric status code flows back from `Invoke-Main`, eliminating the spurious wrapper error.

## Verification

- Parse: clean (`Parser::ParseFile` → OK).
- Lint: only the intentional `PSAvoidUsingWriteHost` warnings documented in `AGENTS.md`.
- Ran the script on the Linux VM: all three CIM cmdlets are unavailable in `pwsh` on Linux (CIM cmdlets are Windows-only — they exist in Windows PowerShell 5.1, the actual target). Each query failure was caught and reported gracefully; the script exited 0 instead of falling over. On Windows PS 5.1 the queries return real data and the operator will see the active pagefile's size from `Win32_PageFileUsage` even when the FileSystem provider would have lied.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1199d57b-c106-4ab1-a8b6-209f5296fa79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1199d57b-c106-4ab1-a8b6-209f5296fa79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

