### PR TITLE
Fix attrib "Parameter format not correct" in OneDriveFreeUpDiskSpace

### DIFF
--- a/windows/disk/OneDriveFreeUpDiskSpace.ps1
+++ b/windows/disk/OneDriveFreeUpDiskSpace.ps1
@@ -38,13 +38,12 @@ function Invoke-AttribDehydrate {
         [string]$FilePath
     )
 
-    $attrib = Join-Path $env:SystemRoot 'System32\attrib.exe'
-    if (-not (Test-Path -LiteralPath $attrib)) {
-        throw "attrib.exe not found at $attrib"
-    }
-
-    $p = Start-Process -FilePath $attrib -ArgumentList @('+U', '-P', $FilePath) -Wait -NoNewWindow -PassThru
-    return $p.ExitCode
+    # Call attrib.exe directly so PowerShell native-command quoting handles paths
+    # with spaces, commas, brackets, and other characters. Start-Process
+    # -ArgumentList does not quote arguments and produced
+    # "Parameter format not correct" errors on real OneDrive paths.
+    $null = & attrib.exe +U -P $FilePath 2>&1
+    return $LASTEXITCODE
 }
 
 function Invoke-Main {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Running `windows/disk/OneDriveFreeUpDiskSpace.ps1` produced `Parameter format not correct -` for every matched file:

```
Running attrib +U -P on matched files...
Parameter format not correct -
Parameter format not correct -
...
```

## Root cause

`Invoke-AttribDehydrate` invoked `attrib.exe` via `Start-Process -ArgumentList @('+U', '-P', $FilePath)`. `Start-Process -ArgumentList` does **not** quote individual arguments — it concatenates them with spaces. As soon as a real OneDrive path contained a space, comma, bracket, ampersand, etc., `attrib.exe` saw a malformed command line and rejected it with "Parameter format not correct".

The reference snippet in the issue worked because it called `attrib.exe` directly via PowerShell's call operator, which handles native-command argument quoting correctly.

## Fix

Switch `Invoke-AttribDehydrate` to call `attrib.exe` directly and read `$LASTEXITCODE`:

```powershell
$null = & attrib.exe +U -P $FilePath 2>&1
return $LASTEXITCODE
```

Behavior preserved:
- Single-pass enumeration, age cutoff, batched progress, summary, and free-space delta are all unchanged.
- Success/failure counters still work via the returned exit code.
- `Invoke-Main` entry-point pattern, comment-based help, and `Read-Host`-only input style remain compliant with `docs/POWERSHELL_SCRIPT_STANDARDS.md`.

## Testing

- ✅ Parse check: `[Parser]::ParseFile(...)` reports `OK`.
- ✅ `Invoke-ScriptAnalyzer`: only the pre-existing intentional `PSAvoidUsingWriteHost` warnings and the pre-existing `PSUseSingularNouns` warning on `Read-PositiveIntDays`. No new findings.
- ⚠️ End-to-end execution requires Windows PowerShell 5.1 with a real OneDrive sync root and cannot be performed on this Linux VM (per `AGENTS.md`). The fix is a direct port of the exact `attrib.exe` invocation pattern from the user-supplied reference script that they confirmed works.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5573df14-e7c1-4a5c-8acb-9bd998e8001f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5573df14-e7c1-4a5c-8acb-9bd998e8001f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

