### PR TITLE
Fix RobustFolderClean robocopy invocation for paths with spaces

### DIFF
--- a/windows/disk/RobustFolderClean.ps1
+++ b/windows/disk/RobustFolderClean.ps1
@@ -50,15 +50,14 @@ function Invoke-RobocopyMirrorEmpty {
         throw "robocopy.exe not found at $robocopy"
     }
 
-    $proc = Start-Process -FilePath $robocopy -ArgumentList @(
-        $EmptySource,
-        $TargetPath,
-        '/MIR',
-        '/R:1',
-        '/W:1'
-    ) -Wait -NoNewWindow -PassThru
+    # Trim trailing backslashes — robocopy mis-parses quoted paths ending in '\'
+    # (e.g. "C:\foo\" becomes C:\foo" to its argv parser).
+    $src = $EmptySource.TrimEnd('\')
+    $dst = $TargetPath.TrimEnd('\')
 
-    return $proc.ExitCode
+    $robocopyArgs = @($src, $dst, '/MIR', '/R:1', '/W:1')
+    & $robocopy @robocopyArgs
+    return $LASTEXITCODE
 }
 
 function Test-RobocopySuccess {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`RobustFolderClean.ps1` fails with `ERROR : Invalid Parameter #3` when the target path contains a space (e.g. `C:\Users\All Users\Dell\SARemediation\SystemRepair\Snapshots`).

The script invokes robocopy via:

```powershell
Start-Process -FilePath $robocopy -ArgumentList @($EmptySource, $TargetPath, '/MIR', '/R:1', '/W:1') ...
```

`Start-Process -ArgumentList` joins array elements with spaces but does **not** auto-quote individual elements that contain spaces. So robocopy.exe is invoked with a command line like:

```
robocopy.exe C:\Temp\RobustFolderClean_…\ C:\Users\All Users\Dell\…\Snapshots /MIR /R:1 /W:1
```

Robocopy's argv parser then sees the destination as `C:\Users\All` and treats `Users\Dell\…\Snapshots` as an unexpected positional argument — hence `Invalid Parameter #3`. The robocopy banner in the failing run confirms this: `Dest - C:\Users\All\`.

## Fix

Drop `Start-Process` and invoke robocopy directly via the call operator with splatting:

```powershell
$robocopyArgs = @($src, $dst, '/MIR', '/R:1', '/W:1')
& $robocopy @robocopyArgs
return $LASTEXITCODE
```

PowerShell's native argument handling for external executables quotes each splatted element correctly when it contains spaces, so robocopy receives the source and destination as single tokens.

Also trim trailing backslashes from source/destination before the call. Robocopy mis-parses quoted paths ending in `\` (the trailing `\` escapes the closing quote in its argv parser, so `"C:\foo\"` becomes `C:\foo"`). This is defensive — `New-RobocopyStagingFolder` and the user prompt don't currently produce trailing slashes, but it costs nothing and prevents a foot-gun.

## Verification

- `pwsh` AST parse: OK
- `Invoke-ScriptAnalyzer`: only pre-existing `PSAvoidUsingWriteHost` / `PSUseApprovedVerbs` warnings (per `AGENTS.md`, those are intentional for operator-facing RMM scripts). No new findings.
- End-to-end execution requires Windows PowerShell 5.1 with robocopy.exe, which is not available on this Linux VM — not run here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af5e41bb-811a-42dc-bf7c-9a70142f9a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af5e41bb-811a-42dc-bf7c-9a70142f9a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

