### PR TITLE
Pipe robocopy output to Out-Host in RobustFolderClean

### DIFF
--- a/windows/disk/RobustFolderClean.ps1
+++ b/windows/disk/RobustFolderClean.ps1
@@ -56,7 +56,10 @@ function Invoke-RobocopyMirrorEmpty {
     $dst = $TargetPath.TrimEnd('\')
 
     $robocopyArgs = @($src, $dst, '/MIR', '/R:1', '/W:1')
-    & $robocopy @robocopyArgs
+    # Pipe to Out-Host so robocopy's banner/progress reaches the operator
+    # but is not collected into the function's return value (which would
+    # otherwise be an Object[] of [stdout lines + exit code]).
+    & $robocopy @robocopyArgs | Out-Host
     return $LASTEXITCODE
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After PR #17 swapped `Start-Process` for direct invocation via `& $robocopy @args`, the script now fails on a real run with:

```
[ERROR] Cannot process argument transformation on parameter 'ExitCode'.
Cannot convert the "System.Object[]" value of type "System.Object[]" to type "System.Int32".
```

## Root cause

`Start-Process -NoNewWindow -Wait` routed robocopy's stdout (the `ROBOCOPY ::` banner, source/dest header, progress lines) directly to the console — it never entered PowerShell's pipeline.

After switching to `& $robocopy @args`, robocopy's stdout now flows through the pipeline. PowerShell collects every uncaptured output value from a function body as the return value, so `Invoke-RobocopyMirrorEmpty` was returning:

```
@(<banner string>, <"-----"> , <"   Source - ...">, ..., <int $LASTEXITCODE>)
```

`Test-RobocopySuccess` declares its parameter as `[int]$ExitCode`, and the `Object[]`-to-`Int32` coercion fails — hence the `Cannot process argument transformation` error.

## Fix

Pipe robocopy's stdout to `Out-Host`. The operator still sees the banner/progress (Out-Host writes straight to the host), but those strings don't enter the function's return-value collection. `$LASTEXITCODE` is unaffected and still carries robocopy's real exit code.

```powershell
& $robocopy @robocopyArgs | Out-Host
return $LASTEXITCODE
```

Considered alternatives:
- `[void](& $robocopy @robocopyArgs)` / `| Out-Null` — would suppress robocopy's output entirely, hiding useful diagnostics from the operator.
- Going back to `Start-Process` — would re-introduce the original quoting bug PR #17 fixed.
- `*> $null` — same issue as `Out-Null`; loses the operator-visible progress.

`Out-Host` keeps the operator UX of `Start-Process -NoNewWindow` (output appears in the same window) while keeping the correct quoting behavior of `& $exe @args`.

## Verification

- `pwsh` AST parse: OK
- `Invoke-ScriptAnalyzer`: no new findings beyond the pre-existing `PSAvoidUsingWriteHost` etc. that `AGENTS.md` documents as intentional.
- End-to-end execution requires Windows + robocopy.exe; not run on this Linux VM.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af5e41bb-811a-42dc-bf7c-9a70142f9a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af5e41bb-811a-42dc-bf7c-9a70142f9a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

