### PR TITLE
DiskCleanup: scope Recycle Bin cleanup to C drive only

### DIFF
--- a/windows/disk/DiskCleanup.ps1
+++ b/windows/disk/DiskCleanup.ps1
@@ -1,11 +1,11 @@
 <#
 .SYNOPSIS
-    Clears common Windows caches and temporary data on the system drive.
+    Empties the Recycle Bin on the C drive for all user profiles.
 .DESCRIPTION
-    Removes files under well-known temp, update, WER, prefetch, and optional user-profile
-    cache paths; runs cleanmgr and DISM component cleanup automatically when elevated.
-    Profile-bound steps run only when not executing as LocalSystem.
-    All choices are made through Read-Host prompts (no script parameters).
+    Deletes all items under C:\$Recycle.Bin for every SID sub-folder, leaving
+    desktop.ini intact. Requires elevation to clear bins belonging to other
+    user profiles. All choices are made through Read-Host prompts (no script
+    parameters).
 #>
 
 Set-StrictMode -Version Latest
@@ -29,99 +29,34 @@ function Test-IsAdministrator {
     return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
-function Test-IsLocalSystem {
-    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
-    return ($id.User.Value -eq 'S-1-5-18')
-}
+function Clear-CRecycleBin {
+    Write-Output 'Cleaning: Recycle Bin (C drive, all users)'
 
-function Remove-FilesSafely {
-    param(
-        [Parameter(Mandatory)]
-        [string]$Path,
-        [Parameter(Mandatory)]
-        [string]$Description
-    )
-
-    if (-not (Test-Path -LiteralPath $Path)) {
+    $binRoot = 'C:\$Recycle.Bin'
+    if (-not (Test-Path -LiteralPath $binRoot)) {
+        Write-Output '  Recycle Bin path not found on C:.'
         return
     }
 
-    try {
-        $items = Get-ChildItem -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
-        $count = ($items | Measure-Object).Count
-
-        if ($count -gt 0) {
-            Write-Output "Cleaning: $Description"
-            $wildcard = Join-Path $Path '*'
-            Remove-Item -Path $wildcard -Recurse -Force -ErrorAction SilentlyContinue
-            Write-Output "  Removed $count item(s) under $Path"
-        }
-    }
-    catch {
-        Write-Warning "Could not clean: $Path — $($_.Exception.Message)"
-    }
-}
-
-function Invoke-DismWithExitCheck {
-    param(
-        [Parameter(Mandatory)]
-        [string[]]$ArgumentList,
-        [Parameter(Mandatory)]
-        [string]$StepName
-    )
-
-    $dism = Join-Path $env:SystemRoot 'System32\Dism.exe'
-    if (-not (Test-Path -LiteralPath $dism)) {
-        Write-Warning "DISM not found at $dism; skipping $StepName."
-        return
-    }
-
-    $proc = Start-Process -FilePath $dism -ArgumentList $ArgumentList -Wait -NoNewWindow -PassThru
-    if ($proc.ExitCode -ne 0) {
-        Write-Warning "$StepName exited with code $($proc.ExitCode)."
-    }
-    else {
-        Write-Output "  $StepName completed (exit 0)."
-    }
-}
-
-function Clear-AllRecycleBin {
-    Write-Output 'Cleaning: Recycle Bin (all users, all fixed drives)'
-
-    try {
-        $driveRoots = Get-CimInstance -ClassName Win32_LogicalDisk -Filter 'DriveType=3' -ErrorAction Stop |
-            ForEach-Object { "$($_.DeviceID)\" }
-    }
-    catch {
-        $driveRoots = Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue |
-            Where-Object { $_.Root -match '^[A-Za-z]:\\$' } |
-            ForEach-Object { $_.Root }
-    }
+    $sidFolders = Get-ChildItem -LiteralPath $binRoot -Force -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like 'S-1-5-*' }
 
     $touched = $false
-    foreach ($root in $driveRoots) {
-        $binRoot = Join-Path $root '$Recycle.Bin'
-        if (-not (Test-Path -LiteralPath $binRoot)) { continue }
-
-        $sidFolders = Get-ChildItem -LiteralPath $binRoot -Force -Directory -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -like 'S-1-5-*' }
-
-        foreach ($sidFolder in $sidFolders) {
-            try {
-                $items = Get-ChildItem -LiteralPath $sidFolder.FullName -Force -ErrorAction SilentlyContinue |
-                    Where-Object { $_.Name -ne 'desktop.ini' }
-                $count = ($items | Measure-Object).Count
-                if ($count -gt 0) {
-                    foreach ($item in $items) {
-                        Remove-Item -LiteralPath $item.FullName -Recurse -Force -ErrorAction SilentlyContinue
-                    }
-                    $touched = $true
-                    Write-Output "  Removed $count item(s) under $($sidFolder.FullName)"
+    foreach ($sidFolder in $sidFolders) {
+        try {
+            $items = Get-ChildItem -LiteralPath $sidFolder.FullName -Force -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -ne 'desktop.ini' }
+            $count = ($items | Measure-Object).Count
+            if ($count -gt 0) {
+                foreach ($item in $items) {
+                    Remove-Item -LiteralPath $item.FullName -Recurse -Force -ErrorAction SilentlyContinue
                 }
+                $touched = $true
+                Write-Output "  Removed $count item(s) under $($sidFolder.FullName)"
             }
-            catch {
-                Write-Warning "Could not clear $($sidFolder.FullName) — $($_.Exception.Message)"
-            }
+        }
+        catch {
+            Write-Warning "Could not clear $($sidFolder.FullName) — $($_.Exception.Message)"
         }
     }
 
@@ -130,145 +65,43 @@ function Clear-AllRecycleBin {
     }
 }
 
-function Invoke-CleanMgrSageRun {
-    $volumeCachesPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches'
-    if (-not (Test-Path -LiteralPath $volumeCachesPath)) {
-        Write-Warning "VolumeCaches registry path not found; skipping cleanmgr configuration."
-        return
-    }
-
-    try {
-        $caches = Get-ChildItem -Path $volumeCachesPath -ErrorAction Stop
-        foreach ($cache in $caches) {
-            Set-ItemProperty -Path $cache.PSPath -Name 'StateFlags0001' -Value 2 -ErrorAction SilentlyContinue
-        }
-
-        $proc = Start-Process -FilePath 'cleanmgr.exe' -ArgumentList '/sagerun:1' -Wait -WindowStyle Hidden -PassThru
-        if ($proc.ExitCode -ne 0) {
-            Write-Warning "cleanmgr exited with code $($proc.ExitCode)."
-        }
-        else {
-            Write-Output "  Disk Cleanup utility (sagerun) finished (exit 0)."
-        }
-    }
-    catch {
-        Write-Warning "Could not run Disk Cleanup utility — $($_.Exception.Message)"
-    }
-}
-
 function Invoke-Main {
-    # --- Input collection and validation ---
-    $isAdmin = Test-IsAdministrator
-    $isSystem = Test-IsLocalSystem
-
-    if (-not $isAdmin) {
-        Write-Warning 'Not running elevated: admin-only steps (Windows Update cache, Prefetch, Delivery Optimization, cleanmgr, DISM) will be skipped.'
+    if (-not (Test-IsAdministrator)) {
+        Write-Warning 'Not running elevated: bins belonging to other user profiles may not be cleared.'
     }
 
-    Write-Output 'This script deletes temporary files, caches, and when elevated runs cleanmgr (Disk Cleanup) and DISM /ResetBase.'
-    Write-Output 'Profile cache steps are skipped when running as LocalSystem.'
-    if (-not (Test-ReadHostYes -Prompt 'Continue with cleanup? (Y/N)')) {
+    Write-Output 'This script empties the Recycle Bin on the C drive for all user profiles.'
+    if (-not (Test-ReadHostYes -Prompt 'Continue? (Y/N)')) {
         Write-Output 'Aborted by operator.'
         return
     }
 
-    # --- Main execution ---
     $drive = Get-PSDrive -Name C -ErrorAction Stop
-    $initialFreeSpace = [math]::Round($drive.Free / 1GB, 2)
-    $totalSpace = [math]::Round(($drive.Used + $drive.Free) / 1GB, 2)
-    $initialPercentFree = 0
+    $initialFree = [math]::Round($drive.Free / 1GB, 2)
+    $total = [math]::Round(($drive.Used + $drive.Free) / 1GB, 2)
+    $initialPct = 0
     if (($drive.Used + $drive.Free) -ne 0) {
-        $initialPercentFree = [math]::Round(($drive.Free / ($drive.Used + $drive.Free)) * 100, 2)
+        $initialPct = [math]::Round(($drive.Free / ($drive.Used + $drive.Free)) * 100, 2)
     }
+    Write-Output "Initial free space on C: $initialFree GB of $total GB ($initialPct%)"
 
-    Write-Output "Initial free space on C: $initialFreeSpace GB of $totalSpace GB ($initialPercentFree%)"
-
-    Remove-FilesSafely -Path 'C:\Windows\Temp' -Description 'Windows Temp folder'
-
-    if (-not $isSystem) {
-        $tempPath = [System.IO.Path]::GetTempPath().TrimEnd('\')
-        Remove-FilesSafely -Path $tempPath -Description 'Current user Temp folder'
-    }
-
-    if (-not (Test-Path -LiteralPath 'C:\Temp')) {
-        New-Item -ItemType Directory -Path 'C:\Temp' -Force | Out-Null
-    }
-    Remove-FilesSafely -Path 'C:\Temp' -Description 'C:\Temp folder'
-
-    Clear-AllRecycleBin
-
-    if ($isAdmin) {
-        Remove-FilesSafely -Path 'C:\Windows\SoftwareDistribution\Download' -Description 'Windows Update cache'
-    }
-
-    Remove-FilesSafely -Path 'C:\ProgramData\Microsoft\Windows\WER\ReportQueue' -Description 'Windows Error Reports'
-    Remove-FilesSafely -Path 'C:\ProgramData\Microsoft\Windows\WER\ReportArchive' -Description 'Windows Error Report Archives'
-
-    if ($isAdmin) {
-        Remove-FilesSafely -Path 'C:\Windows\Prefetch' -Description 'Prefetch files'
-    }
-
-    if (-not $isSystem) {
-        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Microsoft\Windows\Explorer') -Description 'Thumbnail cache'
-
-        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Microsoft\Edge\User Data\Default\Cache') -Description 'Microsoft Edge cache'
-        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Microsoft\Edge\User Data\Default\Code Cache') -Description 'Microsoft Edge code cache'
-
-        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Google\Chrome\User Data\Default\Cache') -Description 'Google Chrome cache'
-        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Google\Chrome\User Data\Default\Code Cache') -Description 'Google Chrome code cache'
-
-        $ffProfilesRoot = Join-Path $env:LOCALAPPDATA 'Mozilla\Firefox\Profiles'
-        if (Test-Path -LiteralPath $ffProfilesRoot) {
-            Get-ChildItem -LiteralPath $ffProfilesRoot -Directory -ErrorAction SilentlyContinue | ForEach-Object {
-                $cache2 = Join-Path $_.FullName 'cache2'
-                Remove-FilesSafely -Path $cache2 -Description "Firefox cache ($($_.Name))"
-            }
-        }
-    }
-    else {
-        Write-Output 'Skipping current-user profile caches (running as LocalSystem).'
-    }
-
-    if ($isAdmin) {
-        Remove-FilesSafely -Path 'C:\Windows\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Cache' -Description 'Delivery Optimization cache'
-    }
-
-    Remove-FilesSafely -Path 'C:\Windows\Downloaded Program Files' -Description 'Downloaded Program Files'
-
-    if (Test-Path -LiteralPath 'C:\inetpub\logs\LogFiles') {
-        Remove-FilesSafely -Path 'C:\inetpub\logs\LogFiles' -Description 'IIS Log Files'
-    }
-
-    if ($isAdmin) {
-        Write-Output ''
-        Write-Output 'Running Windows Disk Cleanup utility (cleanmgr /sagerun); sets HKLM VolumeCaches flags and may show UI on some systems.'
-        Invoke-CleanMgrSageRun
-    }
-
-    if ($isAdmin) {
-        Write-Output 'Analyzing Windows Component Store (DISM)...'
-        Invoke-DismWithExitCheck -ArgumentList @('/Online', '/Cleanup-Image', '/AnalyzeComponentStore', '/NoRestart', '/Quiet') -StepName 'DISM AnalyzeComponentStore'
-
-        Write-Output 'Cleaning Windows Component Store (DISM /StartComponentCleanup /ResetBase)...'
-        Invoke-DismWithExitCheck -ArgumentList @('/Online', '/Cleanup-Image', '/StartComponentCleanup', '/ResetBase', '/NoRestart', '/Quiet') -StepName 'DISM StartComponentCleanup'
-    }
+    Clear-CRecycleBin
 
     $drive = Get-PSDrive -Name C -ErrorAction Stop
-    $finalFreeSpace = [math]::Round($drive.Free / 1GB, 2)
-    $finalPercentFree = 0
+    $finalFree = [math]::Round($drive.Free / 1GB, 2)
+    $finalPct = 0
     if (($drive.Used + $drive.Free) -ne 0) {
-        $finalPercentFree = [math]::Round(($drive.Free / ($drive.Used + $drive.Free)) * 100, 2)
+        $finalPct = [math]::Round(($drive.Free / ($drive.Used + $drive.Free)) * 100, 2)
     }
-
-    $freedSpace = [math]::Round($finalFreeSpace - $initialFreeSpace, 2)
-    $percentPointsChange = [math]::Round($finalPercentFree - $initialPercentFree, 2)
+    $freed = [math]::Round($finalFree - $initialFree, 2)
+    $pctChange = [math]::Round($finalPct - $initialPct, 2)
 
     Write-Output ''
     Write-Output 'Cleanup complete.'
-    Write-Output "Drive size:         $totalSpace GB"
-    Write-Output "Initial free space: $initialFreeSpace GB ($initialPercentFree%)"
-    Write-Output "Final free space:   $finalFreeSpace GB ($finalPercentFree%)"
-    Write-Output "Space freed:        $freedSpace GB (free % change: $percentPointsChange)"
+    Write-Output "Drive size:         $total GB"
+    Write-Output "Initial free space: $initialFree GB ($initialPct%)"
+    Write-Output "Final free space:   $finalFree GB ($finalPct%)"
+    Write-Output "Space freed:        $freed GB (free % change: $pctChange)"
 }
 
 try {

--- a/windows/disk/DiskCleanup.ps1
+++ b/windows/disk/DiskCleanup.ps1
@@ -1,11 +1,11 @@
 <#
 .SYNOPSIS
-    Empties the Recycle Bin on the C drive for all user profiles.
+    Clears common Windows caches and temporary data on the system drive.
 .DESCRIPTION
-    Deletes all items under C:\$Recycle.Bin for every SID sub-folder, leaving
-    desktop.ini intact. Requires elevation to clear bins belonging to other
-    user profiles. All choices are made through Read-Host prompts (no script
-    parameters).
+    Removes files under well-known temp, update, WER, prefetch, and optional user-profile
+    cache paths; runs cleanmgr and DISM component cleanup automatically when elevated.
+    Profile-bound steps run only when not executing as LocalSystem.
+    All choices are made through Read-Host prompts (no script parameters).
 #>
 
 Set-StrictMode -Version Latest
@@ -29,8 +29,64 @@ function Test-IsAdministrator {
     return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
-function Clear-CRecycleBin {
-    Write-Output 'Cleaning: Recycle Bin (C drive, all users)'
+function Test-IsLocalSystem {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    return ($id.User.Value -eq 'S-1-5-18')
+}
+
+function Remove-FilesSafely {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [string]$Description
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+
+    try {
+        $items = Get-ChildItem -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+        $count = ($items | Measure-Object).Count
+
+        if ($count -gt 0) {
+            Write-Output "Cleaning: $Description"
+            $wildcard = Join-Path $Path '*'
+            Remove-Item -Path $wildcard -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Output "  Removed $count item(s) under $Path"
+        }
+    }
+    catch {
+        Write-Warning "Could not clean: $Path — $($_.Exception.Message)"
+    }
+}
+
+function Invoke-DismWithExitCheck {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$ArgumentList,
+        [Parameter(Mandatory)]
+        [string]$StepName
+    )
+
+    $dism = Join-Path $env:SystemRoot 'System32\Dism.exe'
+    if (-not (Test-Path -LiteralPath $dism)) {
+        Write-Warning "DISM not found at $dism; skipping $StepName."
+        return
+    }
+
+    $proc = Start-Process -FilePath $dism -ArgumentList $ArgumentList -Wait -NoNewWindow -PassThru
+    if ($proc.ExitCode -ne 0) {
+        Write-Warning "$StepName exited with code $($proc.ExitCode)."
+    }
+    else {
+        Write-Output "  $StepName completed (exit 0)."
+    }
+}
+
+function Clear-AllRecycleBin {
+    Write-Output 'Cleaning: Recycle Bin (all users, C drive)'
 
     $binRoot = 'C:\$Recycle.Bin'
     if (-not (Test-Path -LiteralPath $binRoot)) {
@@ -65,43 +121,145 @@ function Clear-CRecycleBin {
     }
 }
 
-function Invoke-Main {
-    if (-not (Test-IsAdministrator)) {
-        Write-Warning 'Not running elevated: bins belonging to other user profiles may not be cleared.'
+function Invoke-CleanMgrSageRun {
+    $volumeCachesPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches'
+    if (-not (Test-Path -LiteralPath $volumeCachesPath)) {
+        Write-Warning "VolumeCaches registry path not found; skipping cleanmgr configuration."
+        return
     }
 
-    Write-Output 'This script empties the Recycle Bin on the C drive for all user profiles.'
-    if (-not (Test-ReadHostYes -Prompt 'Continue? (Y/N)')) {
+    try {
+        $caches = Get-ChildItem -Path $volumeCachesPath -ErrorAction Stop
+        foreach ($cache in $caches) {
+            Set-ItemProperty -Path $cache.PSPath -Name 'StateFlags0001' -Value 2 -ErrorAction SilentlyContinue
+        }
+
+        $proc = Start-Process -FilePath 'cleanmgr.exe' -ArgumentList '/sagerun:1' -Wait -WindowStyle Hidden -PassThru
+        if ($proc.ExitCode -ne 0) {
+            Write-Warning "cleanmgr exited with code $($proc.ExitCode)."
+        }
+        else {
+            Write-Output "  Disk Cleanup utility (sagerun) finished (exit 0)."
+        }
+    }
+    catch {
+        Write-Warning "Could not run Disk Cleanup utility — $($_.Exception.Message)"
+    }
+}
+
+function Invoke-Main {
+    # --- Input collection and validation ---
+    $isAdmin = Test-IsAdministrator
+    $isSystem = Test-IsLocalSystem
+
+    if (-not $isAdmin) {
+        Write-Warning 'Not running elevated: admin-only steps (Windows Update cache, Prefetch, Delivery Optimization, cleanmgr, DISM) will be skipped.'
+    }
+
+    Write-Output 'This script deletes temporary files, caches, and when elevated runs cleanmgr (Disk Cleanup) and DISM /ResetBase.'
+    Write-Output 'Profile cache steps are skipped when running as LocalSystem.'
+    if (-not (Test-ReadHostYes -Prompt 'Continue with cleanup? (Y/N)')) {
         Write-Output 'Aborted by operator.'
         return
     }
 
+    # --- Main execution ---
     $drive = Get-PSDrive -Name C -ErrorAction Stop
-    $initialFree = [math]::Round($drive.Free / 1GB, 2)
-    $total = [math]::Round(($drive.Used + $drive.Free) / 1GB, 2)
-    $initialPct = 0
+    $initialFreeSpace = [math]::Round($drive.Free / 1GB, 2)
+    $totalSpace = [math]::Round(($drive.Used + $drive.Free) / 1GB, 2)
+    $initialPercentFree = 0
     if (($drive.Used + $drive.Free) -ne 0) {
-        $initialPct = [math]::Round(($drive.Free / ($drive.Used + $drive.Free)) * 100, 2)
+        $initialPercentFree = [math]::Round(($drive.Free / ($drive.Used + $drive.Free)) * 100, 2)
     }
-    Write-Output "Initial free space on C: $initialFree GB of $total GB ($initialPct%)"
 
-    Clear-CRecycleBin
+    Write-Output "Initial free space on C: $initialFreeSpace GB of $totalSpace GB ($initialPercentFree%)"
+
+    Remove-FilesSafely -Path 'C:\Windows\Temp' -Description 'Windows Temp folder'
+
+    if (-not $isSystem) {
+        $tempPath = [System.IO.Path]::GetTempPath().TrimEnd('\')
+        Remove-FilesSafely -Path $tempPath -Description 'Current user Temp folder'
+    }
+
+    if (-not (Test-Path -LiteralPath 'C:\Temp')) {
+        New-Item -ItemType Directory -Path 'C:\Temp' -Force | Out-Null
+    }
+    Remove-FilesSafely -Path 'C:\Temp' -Description 'C:\Temp folder'
+
+    Clear-AllRecycleBin
+
+    if ($isAdmin) {
+        Remove-FilesSafely -Path 'C:\Windows\SoftwareDistribution\Download' -Description 'Windows Update cache'
+    }
+
+    Remove-FilesSafely -Path 'C:\ProgramData\Microsoft\Windows\WER\ReportQueue' -Description 'Windows Error Reports'
+    Remove-FilesSafely -Path 'C:\ProgramData\Microsoft\Windows\WER\ReportArchive' -Description 'Windows Error Report Archives'
+
+    if ($isAdmin) {
+        Remove-FilesSafely -Path 'C:\Windows\Prefetch' -Description 'Prefetch files'
+    }
+
+    if (-not $isSystem) {
+        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Microsoft\Windows\Explorer') -Description 'Thumbnail cache'
+
+        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Microsoft\Edge\User Data\Default\Cache') -Description 'Microsoft Edge cache'
+        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Microsoft\Edge\User Data\Default\Code Cache') -Description 'Microsoft Edge code cache'
+
+        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Google\Chrome\User Data\Default\Cache') -Description 'Google Chrome cache'
+        Remove-FilesSafely -Path (Join-Path $env:LOCALAPPDATA 'Google\Chrome\User Data\Default\Code Cache') -Description 'Google Chrome code cache'
+
+        $ffProfilesRoot = Join-Path $env:LOCALAPPDATA 'Mozilla\Firefox\Profiles'
+        if (Test-Path -LiteralPath $ffProfilesRoot) {
+            Get-ChildItem -LiteralPath $ffProfilesRoot -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+                $cache2 = Join-Path $_.FullName 'cache2'
+                Remove-FilesSafely -Path $cache2 -Description "Firefox cache ($($_.Name))"
+            }
+        }
+    }
+    else {
+        Write-Output 'Skipping current-user profile caches (running as LocalSystem).'
+    }
+
+    if ($isAdmin) {
+        Remove-FilesSafely -Path 'C:\Windows\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization\Cache' -Description 'Delivery Optimization cache'
+    }
+
+    Remove-FilesSafely -Path 'C:\Windows\Downloaded Program Files' -Description 'Downloaded Program Files'
+
+    if (Test-Path -LiteralPath 'C:\inetpub\logs\LogFiles') {
+        Remove-FilesSafely -Path 'C:\inetpub\logs\LogFiles' -Description 'IIS Log Files'
+    }
+
+    if ($isAdmin) {
+        Write-Output ''
+        Write-Output 'Running Windows Disk Cleanup utility (cleanmgr /sagerun); sets HKLM VolumeCaches flags and may show UI on some systems.'
+        Invoke-CleanMgrSageRun
+    }
+
+    if ($isAdmin) {
+        Write-Output 'Analyzing Windows Component Store (DISM)...'
+        Invoke-DismWithExitCheck -ArgumentList @('/Online', '/Cleanup-Image', '/AnalyzeComponentStore', '/NoRestart', '/Quiet') -StepName 'DISM AnalyzeComponentStore'
+
+        Write-Output 'Cleaning Windows Component Store (DISM /StartComponentCleanup /ResetBase)...'
+        Invoke-DismWithExitCheck -ArgumentList @('/Online', '/Cleanup-Image', '/StartComponentCleanup', '/ResetBase', '/NoRestart', '/Quiet') -StepName 'DISM StartComponentCleanup'
+    }
 
     $drive = Get-PSDrive -Name C -ErrorAction Stop
-    $finalFree = [math]::Round($drive.Free / 1GB, 2)
-    $finalPct = 0
+    $finalFreeSpace = [math]::Round($drive.Free / 1GB, 2)
+    $finalPercentFree = 0
     if (($drive.Used + $drive.Free) -ne 0) {
-        $finalPct = [math]::Round(($drive.Free / ($drive.Used + $drive.Free)) * 100, 2)
+        $finalPercentFree = [math]::Round(($drive.Free / ($drive.Used + $drive.Free)) * 100, 2)
     }
-    $freed = [math]::Round($finalFree - $initialFree, 2)
-    $pctChange = [math]::Round($finalPct - $initialPct, 2)
+
+    $freedSpace = [math]::Round($finalFreeSpace - $initialFreeSpace, 2)
+    $percentPointsChange = [math]::Round($finalPercentFree - $initialPercentFree, 2)
 
     Write-Output ''
     Write-Output 'Cleanup complete.'
-    Write-Output "Drive size:         $total GB"
-    Write-Output "Initial free space: $initialFree GB ($initialPct%)"
-    Write-Output "Final free space:   $finalFree GB ($finalPct%)"
-    Write-Output "Space freed:        $freed GB (free % change: $pctChange)"
+    Write-Output "Drive size:         $totalSpace GB"
+    Write-Output "Initial free space: $initialFreeSpace GB ($initialPercentFree%)"
+    Write-Output "Final free space:   $finalFreeSpace GB ($finalPercentFree%)"
+    Write-Output "Space freed:        $freedSpace GB (free % change: $percentPointsChange)"
 }
 
 try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Targets only `C:\$Recycle.Bin` instead of enumerating all fixed drives via WMI/`Get-PSDrive`. All other cleanup steps (temp folders, Windows Update cache, WER, Prefetch, browser caches, Delivery Optimization, Downloaded Program Files, IIS logs, cleanmgr, DISM) are unchanged.

**Change in `Clear-AllRecycleBin`:**
- Removed `Get-CimInstance Win32_LogicalDisk` enumeration and its `Get-PSDrive` fallback.
- Hardcoded path to `C:\$Recycle.Bin`; returns early with a message if the path doesn't exist.
- Updated the `Write-Output` label from `all users, all fixed drives` → `all users, C drive`.

**Checks:**
- ✅ Parse: `OK: DiskCleanup.ps1`
- ✅ Lint: no new findings (two pre-existing warnings unchanged from `main`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d1ed27e-65e3-41d3-b00c-3967d2b728e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d1ed27e-65e3-41d3-b00c-3967d2b728e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

