### PR TITLE
DiskCleanup: scope Recycle Bin cleanup to C drive only, handle long paths

### DIFF
--- a/windows/disk/DiskCleanup.ps1
+++ b/windows/disk/DiskCleanup.ps1
@@ -85,6 +85,39 @@ function Invoke-DismWithExitCheck {
     }
 }
 
+function Remove-RecycleBinItem {
+    param(
+        [Parameter(Mandatory)]
+        [System.IO.FileSystemInfo]$Item,
+        [Parameter(Mandatory)]
+        [string]$EmptyDir
+    )
+
+    if (-not $Item.PSIsContainer) {
+        Remove-Item -LiteralPath $Item.FullName -Force -ErrorAction SilentlyContinue
+        return
+    }
+
+    # Directories may contain paths that exceed MAX_PATH, causing Remove-Item
+    # -Recurse to hang. Mirror an empty directory into the target first to wipe
+    # its contents via robocopy (which handles long paths natively), then remove
+    # the resulting empty directory. The SID folder itself is never touched here.
+    if (-not (Test-Path -LiteralPath $EmptyDir)) {
+        New-Item -ItemType Directory -Path $EmptyDir -Force | Out-Null
+    }
+
+    $proc = Start-Process -FilePath 'robocopy.exe' `
+        -ArgumentList @($EmptyDir, $Item.FullName, '/MIR', '/R:1', '/W:0', '/NFL', '/NDL', '/NJH', '/NJS') `
+        -Wait -NoNewWindow -PassThru
+
+    if ($proc.ExitCode -le 7) {
+        Remove-Item -LiteralPath $Item.FullName -Force -ErrorAction SilentlyContinue
+    }
+    else {
+        Write-Warning "  robocopy /MIR failed (exit $($proc.ExitCode)) for $($Item.FullName)"
+    }
+}
+
 function Clear-AllRecycleBin {
     Write-Output 'Cleaning: Recycle Bin (all users, C drive)'
 
@@ -94,6 +127,7 @@ function Clear-AllRecycleBin {
         return
     }
 
+    $emptyDir = 'C:\empty'
     $sidFolders = Get-ChildItem -LiteralPath $binRoot -Force -Directory -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like 'S-1-5-*' }
 
@@ -105,7 +139,7 @@ function Clear-AllRecycleBin {
             $count = ($items | Measure-Object).Count
             if ($count -gt 0) {
                 foreach ($item in $items) {
-                    Remove-Item -LiteralPath $item.FullName -Recurse -Force -ErrorAction SilentlyContinue
+                    Remove-RecycleBinItem -Item $item -EmptyDir $emptyDir
                 }
                 $touched = $true
                 Write-Output "  Removed $count item(s) under $($sidFolder.FullName)"
@@ -114,6 +148,10 @@ function Clear-AllRecycleBin {
         catch {
             Write-Warning "Could not clear $($sidFolder.FullName) — $($_.Exception.Message)"
         }
+    }
+
+    if (Test-Path -LiteralPath $emptyDir) {
+        Remove-Item -LiteralPath $emptyDir -Force -ErrorAction SilentlyContinue
     }
 
     if (-not $touched) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Targets only `C:\$Recycle.Bin` instead of enumerating all fixed drives via WMI/`Get-PSDrive`. All other cleanup steps (temp folders, Windows Update cache, WER, Prefetch, browser caches, Delivery Optimization, Downloaded Program Files, IIS logs, cleanmgr, DISM) are unchanged.

**Recycle Bin changes:**

1. Drive scope: hardcoded to `C:\$Recycle.Bin` only.
2. Long-path handling: adds `Remove-RecycleBinItem` helper. For file items, `Remove-Item` is called directly. For directory items (e.g. `$RXXXXXX\` folders with deeply nested contents), `robocopy /MIR` mirrors an empty `C:\empty` into the target directory first — this wipes its contents without recursing through PowerShell — then removes the now-empty directory. This prevents the hang that occurs when `Remove-Item -Recurse` encounters paths exceeding MAX_PATH. `C:\empty` is removed when the operation completes.
3. The SID folder under `C:\$Recycle.Bin` is never removed; only the items inside it are.

**Checks:**
- ✅ Parse: `OK: DiskCleanup.ps1`
- ✅ Lint: no new findings (pre-existing warnings unchanged from `main`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d1ed27e-65e3-41d3-b00c-3967d2b728e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d1ed27e-65e3-41d3-b00c-3967d2b728e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

