### PR TITLE
fix: guard missing LoadTime registry values and fix FILETIME sign extension in RemoveOldDomainProfiles

### DIFF
--- a/windows/user-profiles/RemoveOldDomainProfiles.ps1
+++ b/windows/user-profiles/RemoveOldDomainProfiles.ps1
@@ -56,9 +56,9 @@ function Get-DomainProfiles {
     Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\*' |
         Where-Object { $_.PSChildName.Length -gt 20 } |
         ForEach-Object {
-            $high = $_.LocalProfileLoadTimeHigh
-            $low = $_.LocalProfileLoadTimeLow
-            $time = [datetime]::FromFileTime(([long]$high -shl 32) -bor [long]$low)
+            $high = if ($null -ne $_.PSObject.Properties['LocalProfileLoadTimeHigh']) { $_.LocalProfileLoadTimeHigh } else { 0 }
+            $low  = if ($null -ne $_.PSObject.Properties['LocalProfileLoadTimeLow'])  { $_.LocalProfileLoadTimeLow  } else { 0 }
+            $time = [datetime]::FromFileTime(([long]$high -shl 32) -bor ([long]$low -band [long]0xFFFFFFFF))
             [pscustomobject]@{
                 SID = $_.PSChildName
                 ProfilePath = $_.ProfileImagePath


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two bugs fixed in `windows/user-profiles/RemoveOldDomainProfiles.ps1`.

### Bug 1 — StrictMode crash on missing registry values

`LocalProfileLoadTimeHigh` / `LocalProfileLoadTimeLow` are only written to ProfileList when a profile has actually been loaded on the machine. Profiles that exist in the registry but have never been loaded (migrated accounts, manually-created entries, etc.) lack these values entirely. Under `Set-StrictMode -Version Latest`, accessing a missing property throws immediately.

**Fix:** Check `PSObject.Properties` before accessing each value; fall back to `0` so profiles with no load-time record resolve to `1601-01-01` and are always caught by the age filter (operator reviews and confirms at the `Y/N` prompt).

### Bug 2 — FILETIME low-word sign extension corrupts timestamps

Registry `DWORD` values are read by PowerShell as signed `[int32]`. When `LocalProfileLoadTimeLow` has bit 31 set (half the possible range, occurring frequently in real data), casting to `[long]` sign-extends the upper 32 bits to `1`s. The subsequent `-bor` then corrupts the entire 64-bit FILETIME, producing `LastLogon` values wildly in the past or future — a silent wrong-answer bug that could cause profiles to be flagged for deletion that shouldn't be, or skipped when they should be caught.

**Fix:** Mask the low word before ORing: `([long]$low -band [long]0xFFFFFFFF)`.

## Testing

- ✅ Syntax check: `Parser::ParseFile` reports no errors
- ✅ PSScriptAnalyzer: no new findings introduced (all remaining findings are pre-existing naming/convention warnings)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4d23da6-a349-4358-81d1-1b63c3968fa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4d23da6-a349-4358-81d1-1b63c3968fa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

