### PR TITLE
Add DetectCrashLoop.ps1 — auto-detect crash-looping processes across the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Collection of PowerShell used by technicians at an MSP: troubleshooting, cleanup
 | [windows/onboarding](windows/onboarding) | AD user create/copy helpers (see area readme for the CSV). |
 | [windows/software-removal](windows/software-removal) | Third-party software removal (uninstall, services, leftovers). |
 | [windows/network](windows/network) | Network discovery plus current-user drive/printer mapping management. |
+| [windows/monitoring](windows/monitoring) | Read-only runtime health checks and event-driven diagnostics (crash loops, etc.). |
 | [data/templates](data/templates) | Sample data files, such as CSV templates (not customer data). |
 | [m365](m365) | Microsoft 365 scripts (Graph, SharePoint; see folder readme). |
 

--- a/windows/monitoring/DetectCrashLoop.ps1
+++ b/windows/monitoring/DetectCrashLoop.ps1
@@ -1,30 +1,17 @@
 <#
 .SYNOPSIS
-    Detects crash loops for any Windows application by querying the Application event log.
+    Scans the Application event log for crash-looping Windows processes.
 .DESCRIPTION
-    Prompts for a process name, look-back window in minutes, and a crash-count threshold.
-    Queries Application event log IDs 1000 (application error) and 1026 (.NET runtime error)
-    for events matching the process name within the window.
-    Outputs OK (no crashes), WARN (below threshold), or CRASH LOOP (at or above threshold)
-    with rate and timing detail. Read-only; no changes are made to the system.
-    Runs as LocalSystem or elevated admin without non-default module dependencies.
+    Queries Application event log ID 1000 (application error) within a rolling look-back
+    window and groups results by faulting application name (from event Properties[0]).
+    Reports OK (no crashes), WARN (below threshold), or CRASH LOOP (at or above threshold)
+    for each affected process, with crash rate and timing detail. Read-only; no changes
+    are made to the system. Runs as LocalSystem or elevated admin without non-default
+    module dependencies.
 #>
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-
-function Read-NonEmptyInput {
-    param(
-        [Parameter(Mandatory)]
-        [string]$Prompt
-    )
-
-    do {
-        $value = Read-Host -Prompt $Prompt
-    } while ([string]::IsNullOrWhiteSpace($value))
-
-    return $value.Trim()
-}
 
 function Read-PositiveInt {
     param(
@@ -47,58 +34,71 @@ function Read-PositiveInt {
     }
 }
 
-function Get-AppCrashEvent {
-    param(
-        [Parameter(Mandatory)]
-        [string]$ProcessName,
-        [Parameter(Mandatory)]
-        [datetime]$Cutoff
-    )
-
-    $raw = Get-WinEvent -FilterHashtable @{
-        LogName   = 'Application'
-        Id        = @(1000, 1026)
-        StartTime = $Cutoff
-    } -ErrorAction SilentlyContinue
-
-    return @($raw | Where-Object { $_.Message -match [regex]::Escape($ProcessName) })
-}
-
 function Invoke-Main {
-    $processName   = Read-NonEmptyInput -Prompt 'Process name to check (e.g. MyApp.exe)'
-    $windowMinutes = Read-PositiveInt   -Prompt 'Look-back window in minutes'            -Default 10
-    $threshold     = Read-PositiveInt   -Prompt 'Crash count threshold for CRASH LOOP'   -Default 5
+    $windowMinutes = Read-PositiveInt -Prompt 'Look-back window in minutes'          -Default 60
+    $threshold     = Read-PositiveInt -Prompt 'Crash count threshold for CRASH LOOP' -Default 5
 
-    $cutoff      = (Get-Date).AddMinutes(-$windowMinutes)
-    $events      = Get-AppCrashEvent -ProcessName $processName -Cutoff $cutoff
-    $crashEvents = @($events | Where-Object { $_.Id -eq 1000 })
-    $crashCount  = $crashEvents.Count
+    $cutoff = (Get-Date).AddMinutes(-$windowMinutes)
+    Write-Host ''
+    Write-Host "Scanning Application event log (last $windowMinutes minutes, threshold: $threshold)..." -ForegroundColor Cyan
 
-    if ($crashCount -eq 0) {
-        Write-Host "OK — No crashes detected for '$processName' in the last $windowMinutes minutes." -ForegroundColor Green
+    $crashEvents = @(Get-WinEvent -FilterHashtable @{
+        LogName   = 'Application'
+        Id        = 1000
+        StartTime = $cutoff
+    } -ErrorAction SilentlyContinue)
+
+    if ($crashEvents.Count -eq 0) {
+        Write-Host "OK — No application crashes detected in the last $windowMinutes minutes." -ForegroundColor Green
+        return
     }
-    elseif ($crashCount -lt $threshold) {
-        Write-Host "WARN — $crashCount crash(es) detected in the last $windowMinutes minutes (threshold: $threshold). Watch this." -ForegroundColor Yellow
-        $events | Sort-Object TimeCreated -Descending | Select-Object TimeCreated, Id, Message -First 10
-    }
-    else {
-        $sorted   = $crashEvents | Sort-Object TimeCreated
-        $oldest   = ($sorted | Select-Object -First 1).TimeCreated
-        $newest   = ($sorted | Select-Object -Last 1).TimeCreated
-        $spanSecs = [math]::Round(($newest - $oldest).TotalSeconds)
-        $rate     = if ($spanSecs -gt 0) { [math]::Round($crashCount / ($spanSecs / 60), 1) } else { 'N/A' }
 
-        Write-Host ''
-        Write-Host '*** CRASH LOOP DETECTED ***' -ForegroundColor Red
-        Write-Host "  Process   : $processName"                                      -ForegroundColor Red
-        Write-Host "  Crashes   : $crashCount in the last $windowMinutes minutes"    -ForegroundColor Red
-        Write-Host "  Time span : ${spanSecs} seconds"                               -ForegroundColor Red
-        Write-Host "  Rate      : ~${rate} crashes/min"                              -ForegroundColor Red
-        Write-Host ''
-        Write-Host 'Recent crash timestamps:' -ForegroundColor Yellow
-        $sorted | Select-Object -Last 10 | Sort-Object TimeCreated -Descending | ForEach-Object {
-            Write-Host "  $($_.TimeCreated.ToString('HH:mm:ss'))" -ForegroundColor Yellow
+    $grouped = $crashEvents |
+        Group-Object {
+            if ($_.Properties.Count -gt 0) {
+                $n = [string]$_.Properties[0].Value
+                if (-not [string]::IsNullOrWhiteSpace($n)) { $n.Trim() } else { '(unknown)' }
+            } else { '(unknown)' }
+        } |
+        Sort-Object Count -Descending
+
+    $loopCount = 0
+    $warnCount = 0
+
+    foreach ($group in $grouped) {
+        $appName    = $group.Name
+        $count      = $group.Count
+        $appCrashes = @($group.Group | Sort-Object TimeCreated)
+
+        if ($count -lt $threshold) {
+            $warnCount++
+            Write-Host "WARN — $appName : $count crash(es) in the last $windowMinutes minutes (threshold: $threshold)." -ForegroundColor Yellow
+        } else {
+            $loopCount++
+            $oldest   = ($appCrashes | Select-Object -First 1).TimeCreated
+            $newest   = ($appCrashes | Select-Object -Last 1).TimeCreated
+            $spanSecs = [math]::Round(($newest - $oldest).TotalSeconds)
+            $rate     = if ($spanSecs -gt 0) { [math]::Round($count / ($spanSecs / 60), 1) } else { 'N/A' }
+
+            Write-Host ''
+            Write-Host '*** CRASH LOOP DETECTED ***'                                          -ForegroundColor Red
+            Write-Host "  Process   : $appName"                                               -ForegroundColor Red
+            Write-Host "  Crashes   : $count in the last $windowMinutes minutes"              -ForegroundColor Red
+            Write-Host "  Time span : ${spanSecs} seconds"                                    -ForegroundColor Red
+            Write-Host "  Rate      : ~${rate} crashes/min"                                   -ForegroundColor Red
+            Write-Host ''
+            Write-Host '  Recent crash timestamps:' -ForegroundColor Yellow
+            $appCrashes | Select-Object -Last 10 | Sort-Object TimeCreated -Descending | ForEach-Object {
+                Write-Host "    $($_.TimeCreated.ToString('HH:mm:ss'))" -ForegroundColor Yellow
+            }
         }
+    }
+
+    Write-Host ''
+    if ($loopCount -gt 0) {
+        Write-Host "Summary: $loopCount process(es) in CRASH LOOP, $warnCount in WARN state." -ForegroundColor Red
+    } else {
+        Write-Host "Summary: No crash loops detected. $warnCount process(es) with below-threshold crashes." -ForegroundColor Yellow
     }
 }
 

--- a/windows/monitoring/DetectCrashLoop.ps1
+++ b/windows/monitoring/DetectCrashLoop.ps1
@@ -1,0 +1,111 @@
+<#
+.SYNOPSIS
+    Detects crash loops for any Windows application by querying the Application event log.
+.DESCRIPTION
+    Prompts for a process name, look-back window in minutes, and a crash-count threshold.
+    Queries Application event log IDs 1000 (application error) and 1026 (.NET runtime error)
+    for events matching the process name within the window.
+    Outputs OK (no crashes), WARN (below threshold), or CRASH LOOP (at or above threshold)
+    with rate and timing detail. Read-only; no changes are made to the system.
+    Runs as LocalSystem or elevated admin without non-default module dependencies.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Read-NonEmptyInput {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Prompt
+    )
+
+    do {
+        $value = Read-Host -Prompt $Prompt
+    } while ([string]::IsNullOrWhiteSpace($value))
+
+    return $value.Trim()
+}
+
+function Read-PositiveInt {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Prompt,
+        [Parameter(Mandatory)]
+        [int]$Default
+    )
+
+    while ($true) {
+        $raw = Read-Host -Prompt "$Prompt [default: $Default]"
+        if ([string]::IsNullOrWhiteSpace($raw)) {
+            return $Default
+        }
+        $parsed = 0
+        if ([int]::TryParse($raw.Trim(), [ref]$parsed) -and $parsed -gt 0) {
+            return $parsed
+        }
+        Write-Host '  Enter a positive whole number.' -ForegroundColor Yellow
+    }
+}
+
+function Get-AppCrashEvent {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProcessName,
+        [Parameter(Mandatory)]
+        [datetime]$Cutoff
+    )
+
+    $raw = Get-WinEvent -FilterHashtable @{
+        LogName   = 'Application'
+        Id        = @(1000, 1026)
+        StartTime = $Cutoff
+    } -ErrorAction SilentlyContinue
+
+    return @($raw | Where-Object { $_.Message -match [regex]::Escape($ProcessName) })
+}
+
+function Invoke-Main {
+    $processName   = Read-NonEmptyInput -Prompt 'Process name to check (e.g. MyApp.exe)'
+    $windowMinutes = Read-PositiveInt   -Prompt 'Look-back window in minutes'            -Default 10
+    $threshold     = Read-PositiveInt   -Prompt 'Crash count threshold for CRASH LOOP'   -Default 5
+
+    $cutoff      = (Get-Date).AddMinutes(-$windowMinutes)
+    $events      = Get-AppCrashEvent -ProcessName $processName -Cutoff $cutoff
+    $crashEvents = @($events | Where-Object { $_.Id -eq 1000 })
+    $crashCount  = $crashEvents.Count
+
+    if ($crashCount -eq 0) {
+        Write-Host "OK — No crashes detected for '$processName' in the last $windowMinutes minutes." -ForegroundColor Green
+    }
+    elseif ($crashCount -lt $threshold) {
+        Write-Host "WARN — $crashCount crash(es) detected in the last $windowMinutes minutes (threshold: $threshold). Watch this." -ForegroundColor Yellow
+        $events | Sort-Object TimeCreated -Descending | Select-Object TimeCreated, Id, Message -First 10
+    }
+    else {
+        $sorted   = $crashEvents | Sort-Object TimeCreated
+        $oldest   = ($sorted | Select-Object -First 1).TimeCreated
+        $newest   = ($sorted | Select-Object -Last 1).TimeCreated
+        $spanSecs = [math]::Round(($newest - $oldest).TotalSeconds)
+        $rate     = if ($spanSecs -gt 0) { [math]::Round($crashCount / ($spanSecs / 60), 1) } else { 'N/A' }
+
+        Write-Host ''
+        Write-Host '*** CRASH LOOP DETECTED ***' -ForegroundColor Red
+        Write-Host "  Process   : $processName"                                      -ForegroundColor Red
+        Write-Host "  Crashes   : $crashCount in the last $windowMinutes minutes"    -ForegroundColor Red
+        Write-Host "  Time span : ${spanSecs} seconds"                               -ForegroundColor Red
+        Write-Host "  Rate      : ~${rate} crashes/min"                              -ForegroundColor Red
+        Write-Host ''
+        Write-Host 'Recent crash timestamps:' -ForegroundColor Yellow
+        $sorted | Select-Object -Last 10 | Sort-Object TimeCreated -Descending | ForEach-Object {
+            Write-Host "  $($_.TimeCreated.ToString('HH:mm:ss'))" -ForegroundColor Yellow
+        }
+    }
+}
+
+try {
+    Invoke-Main
+}
+catch {
+    Write-Host "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
+    throw
+}

--- a/windows/monitoring/Readme.md
+++ b/windows/monitoring/Readme.md
@@ -1,0 +1,51 @@
+# windows/monitoring
+
+PowerShell helpers for runtime health checks and event-driven diagnostics on Windows endpoints.
+
+## Folder purpose summary
+
+This folder contains read-only diagnostic scripts that query Windows event logs and system state to surface operational problems (crash loops, service failures, etc.) without making changes to the system.
+
+## Script inventory
+
+- `DetectCrashLoop.ps1`
+
+## Safety and impact notes
+
+- All scripts in this folder are **read-only**; no configuration changes or deletions are performed.
+- `Get-WinEvent` queries can be slow on systems with very large event logs; this is expected.
+
+## Validation guidance
+
+- Look for `OK —`, `WARN —`, and `*** CRASH LOOP DETECTED ***` lines in script output.
+- An `[ERROR]` line indicates an unexpected failure; check the message for the specific cause.
+
+---
+
+## DetectCrashLoop.ps1
+
+**Purpose:** Detect whether a named Windows process is crash-looping by counting Application event log ID 1000 (application error) and 1026 (.NET runtime error) events within a rolling time window and comparing against a threshold.
+
+**Execution context:** Intended for **elevated Administrator** or **LocalSystem**. Reading the Application event log requires at least read access to the Security/Event Log; under most RMM deployments this is available as LocalSystem.
+
+**Operator inputs (prompts only — no parameters):**
+
+1. **`Process name to check`** — The executable name to match against event log messages (e.g. `ThreatLockerService.exe`, `MyApp.exe`). Required; blank is rejected.
+2. **`Look-back window in minutes [default: 10]`** — How far back to search for events. Press **Enter** for **10**. Must be a positive integer.
+3. **`Crash count threshold for CRASH LOOP [default: 5]`** — Number of ID 1000 events at or above which a crash loop is declared. Press **Enter** for **5**. Must be a positive integer.
+
+**What it does (summary):**
+
+- Queries Application event log for IDs **1000** and **1026** in the look-back window, filtered to messages containing the process name.
+- Counts **ID 1000** events as crashes.
+- **OK** (green): zero crashes.
+- **WARN** (yellow): crashes detected but below threshold; lists the 10 most recent matching events.
+- **CRASH LOOP** (red): crashes at or above threshold; reports total count, time span between first and last crash, crash rate (crashes/min), and the 10 most recent crash timestamps.
+
+**Commands and APIs used:** `Get-WinEvent`, `Read-Host`, `Where-Object`, `Sort-Object`, `Select-Object`, `Measure-Object`, `[regex]::Escape`, `[math]::Round`.
+
+**File path behavior:** No files read or written; no `C:\Temp` usage.
+
+**Safety / impact:** Read-only. No changes are made to the system.
+
+**Usage:** Paste the entire script into an elevated Windows PowerShell session and answer the prompts, or run `.\DetectCrashLoop.ps1` from this folder.

--- a/windows/monitoring/Readme.md
+++ b/windows/monitoring/Readme.md
@@ -24,25 +24,26 @@ This folder contains read-only diagnostic scripts that query Windows event logs 
 
 ## DetectCrashLoop.ps1
 
-**Purpose:** Detect whether a named Windows process is crash-looping by counting Application event log ID 1000 (application error) and 1026 (.NET runtime error) events within a rolling time window and comparing against a threshold.
+**Purpose:** Automatically detect crash-looping processes across the entire system by scanning Application event log ID 1000 (application error) events, grouping by faulting application name, and comparing each group's crash count against a threshold.
 
 **Execution context:** Intended for **elevated Administrator** or **LocalSystem**. Reading the Application event log requires at least read access to the Security/Event Log; under most RMM deployments this is available as LocalSystem.
 
 **Operator inputs (prompts only — no parameters):**
 
-1. **`Process name to check`** — The executable name to match against event log messages (e.g. `ThreatLockerService.exe`, `MyApp.exe`). Required; blank is rejected.
-2. **`Look-back window in minutes [default: 10]`** — How far back to search for events. Press **Enter** for **10**. Must be a positive integer.
-3. **`Crash count threshold for CRASH LOOP [default: 5]`** — Number of ID 1000 events at or above which a crash loop is declared. Press **Enter** for **5**. Must be a positive integer.
+1. **`Look-back window in minutes [default: 60]`** — How far back to search for events. Press **Enter** for **60**. Must be a positive integer.
+2. **`Crash count threshold for CRASH LOOP [default: 5]`** — Number of ID 1000 events per process at or above which a crash loop is declared. Press **Enter** for **5**. Must be a positive integer.
 
 **What it does (summary):**
 
-- Queries Application event log for IDs **1000** and **1026** in the look-back window, filtered to messages containing the process name.
-- Counts **ID 1000** events as crashes.
-- **OK** (green): zero crashes.
-- **WARN** (yellow): crashes detected but below threshold; lists the 10 most recent matching events.
-- **CRASH LOOP** (red): crashes at or above threshold; reports total count, time span between first and last crash, crash rate (crashes/min), and the 10 most recent crash timestamps.
+- Queries Application event log for ID **1000** within the look-back window.
+- Extracts the faulting application name from each event's structured properties (`Properties[0]`).
+- Groups by application name and evaluates each group:
+  - **OK** (green): no crashes found at all.
+  - **WARN** (yellow): at least one crash but below threshold; one line per affected process.
+  - **CRASH LOOP** (red): crashes at or above threshold; reports total count, time span between first and last crash, crash rate (crashes/min), and the 10 most recent crash timestamps.
+- Prints a summary line showing counts of crash-looping and WARN-state processes.
 
-**Commands and APIs used:** `Get-WinEvent`, `Read-Host`, `Where-Object`, `Sort-Object`, `Select-Object`, `Measure-Object`, `[regex]::Escape`, `[math]::Round`.
+**Commands and APIs used:** `Get-WinEvent`, `Read-Host`, `Group-Object`, `Sort-Object`, `Select-Object`, `[math]::Round`.
 
 **File path behavior:** No files read or written; no `C:\Temp` usage.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `windows/monitoring/DetectCrashLoop.ps1`, a read-only diagnostic script that automatically identifies crash-looping processes by scanning the Application event log — no process name needed.

## How it works

Prompts for:
1. **Look-back window in minutes** — default **60**
2. **Crash count threshold** — default **5**

Queries Application event log ID **1000** (application error) within the window. Extracts the faulting application name from each event's structured properties (`Properties[0]`), groups by application name, and reports per-process:

| Outcome | Condition | Color |
|---|---|---|
| `OK` | No ID-1000 events at all | Green |
| `WARN — <app> : N crash(es)` | Crashes present but below threshold | Yellow |
| `*** CRASH LOOP DETECTED ***` | At or above threshold — shows count, time span, crash rate, 10 most recent timestamps | Red |

Ends with a summary line: `N process(es) in CRASH LOOP, N in WARN state.`

## Standards compliance

- Comment-based help header with `.SYNOPSIS` and `.DESCRIPTION`
- `Set-StrictMode -Version Latest` / `$ErrorActionPreference = 'Stop'`
- No script-level `param` block; operator input via `Read-Host` only
- `Invoke-Main` entry-point pattern for chunked-paste resilience
- No script-scope `exit`
- Read-only; no system changes

## Also

- New `windows/monitoring/Readme.md`
- Root `README.md` updated with `windows/monitoring` in the layout table

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a068092-6596-4742-9e50-4623473ab58d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a068092-6596-4742-9e50-4623473ab58d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

