### PR TITLE
ManageCurrentUserPrinters: show both printer lists on every loop iteration

### DIFF
--- a/windows/network/ManageCurrentUserPrinters.ps1
+++ b/windows/network/ManageCurrentUserPrinters.ps1
@@ -130,7 +130,7 @@ function Show-MappedPrinterConnections {
     )
 
     Write-Host ''
-    Write-Host 'Mapped printer connections:' -ForegroundColor Yellow
+    Write-Host 'Mapped printer connections (Add/Delete registry):' -ForegroundColor Yellow
     if ($Printers.Count -eq 0) {
         Write-Host '  (none found for current user)' -ForegroundColor DarkYellow
         return
@@ -138,6 +138,21 @@ function Show-MappedPrinterConnections {
 
     for ($i = 0; $i -lt $Printers.Count; $i++) {
         Write-Host ("[{0}] {1}" -f ($i + 1), $Printers[$i].PrinterName)
+    }
+}
+
+function Show-InstalledPrinters {
+    $printers = @(Get-Printer -ErrorAction SilentlyContinue | Sort-Object -Property Name)
+
+    Write-Host ''
+    Write-Host 'Installed printers (Rename/Delete spooler):' -ForegroundColor Yellow
+    if ($printers.Count -eq 0) {
+        Write-Host '  (none found)' -ForegroundColor DarkYellow
+        return
+    }
+
+    for ($i = 0; $i -lt $printers.Count; $i++) {
+        Write-Host ("[{0}] {1}" -f ($i + 1), $printers[$i].Name)
     }
 }
 

--- a/windows/network/ManageCurrentUserPrinters.ps1
+++ b/windows/network/ManageCurrentUserPrinters.ps1
@@ -638,6 +638,7 @@ function Invoke-Main {
     while ($true) {
         $mappedPrinters = @(Get-PrinterConnectionsForSid -Sid $targetContext.Sid)
         Show-MappedPrinterConnections -Printers $mappedPrinters
+        Show-InstalledPrinters
 
         Write-Host ''
         Write-Host 'Actions:' -ForegroundColor Yellow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Shows both printer data sources at the top of every menu loop, with headers that make clear which actions each list applies to.

**Changes**

- Updated `Show-MappedPrinterConnections` header to `Mapped printer connections (Add/Delete registry):` so operators know this list drives Add and Delete mode 1.
- Added `Show-InstalledPrinters` function that calls `Get-Printer`, sorts by name, and displays under an `Installed printers (Rename/Delete spooler):` header.
- `Invoke-Main` now calls `Show-InstalledPrinters` immediately after `Show-MappedPrinterConnections` on every loop iteration.

**Before**

Each loop showed only the two registry-mapped connections. The 8-item spooler list only appeared inside the Rename > Interactive sub-flow.

**After**

Both lists appear at the top of every loop, e.g.:

```
Mapped printer connections (Add/Delete registry):
[1] ,,http: 192.168.1.185 3911,
[2] ,,stg-fp01,STG-ADMIN-SHARP-MX3050V

Installed printers (Rename/Delete spooler):
[1] Bluebeam PDF
[2] Fax
[3] Hall Creek Printer (HP LaserJet MFP M140w)
...
```

The Rename > Interactive sub-flow still shows its own numbered installed-printer list for the selection prompt — that is unchanged and required.

**Lint / syntax**

- `ManageCurrentUserPrinters.ps1` parses clean under PowerShell Core.
- One new `PSUseSingularNouns` warning for `Show-InstalledPrinters` — same pre-existing class as `Show-MappedPrinterConnections`; plural is intentional for a list-display function.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2721b90-b204-4596-b6d5-c4bc0339a5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2721b90-b204-4596-b6d5-c4bc0339a5f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

