### PR TITLE
Fix cleanmgr hang under LocalSystem in DiskCleanup.ps1

### DIFF
--- a/windows/disk/DiskCleanup.ps1
+++ b/windows/disk/DiskCleanup.ps1
@@ -172,8 +172,12 @@ function Invoke-CleanMgrSageRun {
             Set-ItemProperty -Path $cache.PSPath -Name 'StateFlags0001' -Value 2 -ErrorAction SilentlyContinue
         }
 
-        $proc = Start-Process -FilePath 'cleanmgr.exe' -ArgumentList '/sagerun:1' -Wait -WindowStyle Hidden -PassThru
-        if ($proc.ExitCode -ne 0) {
+        $proc = Start-Process -FilePath 'cleanmgr.exe' -ArgumentList '/sagerun:1' -WindowStyle Hidden -PassThru
+        if (-not $proc.WaitForExit(300000)) {
+            $proc.Kill()
+            Write-Warning "cleanmgr did not finish within 5 minutes; process was terminated."
+        }
+        elseif ($proc.ExitCode -ne 0) {
             Write-Warning "cleanmgr exited with code $($proc.ExitCode)."
         }
         else {
@@ -268,7 +272,7 @@ function Invoke-Main {
         Remove-FilesSafely -Path 'C:\inetpub\logs\LogFiles' -Description 'IIS Log Files'
     }
 
-    if ($isAdmin) {
+    if ($isAdmin -and -not $isSystem) {
         Write-Output ''
         Write-Output 'Running Windows Disk Cleanup utility (cleanmgr /sagerun); sets HKLM VolumeCaches flags and may show UI on some systems.'
         Invoke-CleanMgrSageRun


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When run via RMM as LocalSystem, the script hung indefinitely at the `cleanmgr /sagerun` step. Two root causes:

1. `$isAdmin` is `$true` for LocalSystem, so the cleanmgr block was not guarded against the LocalSystem context. `cleanmgr.exe` requires an interactive desktop session; under LocalSystem several of its cleanup handlers block on COM/UI calls that never complete.
2. `Start-Process -Wait` has no timeout, so a stalled `cleanmgr.exe` process stalled the entire script permanently.

## Changes

- **`Invoke-Main`:** Added `-and -not $isSystem` to the cleanmgr guard so the block is skipped entirely when running as LocalSystem.
- **`Invoke-CleanMgrSageRun`:** Replaced `-Wait` with `$proc.WaitForExit(300000)` (5-minute ceiling). If cleanmgr does not exit within that window the process is force-killed and a warning is emitted. This protects interactive admin runs where cleanmgr might still misbehave.

## Testing

- ✅ Syntax check: `ParseFile` reports no errors
- ✅ PSScriptAnalyzer: no new warnings introduced (pre-existing warnings unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15a14415-f45a-4324-88c2-fadbd2ffe48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15a14415-f45a-4324-88c2-fadbd2ffe48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

