### PR TITLE
Fix cleanmgr hang and add multi-profile cache cleanup for LocalSystem runs

### DIFF
--- a/windows/disk/DiskCleanup.ps1
+++ b/windows/disk/DiskCleanup.ps1
@@ -172,8 +172,12 @@ function Invoke-CleanMgrSageRun {
             Set-ItemProperty -Path $cache.PSPath -Name 'StateFlags0001' -Value 2 -ErrorAction SilentlyContinue
         }
 
-        $proc = Start-Process -FilePath 'cleanmgr.exe' -ArgumentList '/sagerun:1' -Wait -WindowStyle Hidden -PassThru
-        if ($proc.ExitCode -ne 0) {
+        $proc = Start-Process -FilePath 'cleanmgr.exe' -ArgumentList '/sagerun:1' -WindowStyle Hidden -PassThru
+        if (-not $proc.WaitForExit(300000)) {
+            $proc.Kill()
+            Write-Warning "cleanmgr did not finish within 5 minutes; process was terminated."
+        }
+        elseif ($proc.ExitCode -ne 0) {
             Write-Warning "cleanmgr exited with code $($proc.ExitCode)."
         }
         else {
@@ -268,7 +272,7 @@ function Invoke-Main {
         Remove-FilesSafely -Path 'C:\inetpub\logs\LogFiles' -Description 'IIS Log Files'
     }
 
-    if ($isAdmin) {
+    if ($isAdmin -and -not $isSystem) {
         Write-Output ''
         Write-Output 'Running Windows Disk Cleanup utility (cleanmgr /sagerun); sets HKLM VolumeCaches flags and may show UI on some systems.'
         Invoke-CleanMgrSageRun

--- a/windows/disk/DiskCleanup.ps1
+++ b/windows/disk/DiskCleanup.ps1
@@ -159,6 +159,62 @@ function Clear-AllRecycleBin {
     }
 }
 
+function Get-CleanableUserProfile {
+    # Win32_UserProfile.Special covers LocalSystem, LocalService, NetworkService,
+    # IIS AppPool accounts, and other service/virtual accounts.
+    # Loaded = $true means the profile hive is mounted (user is logged on).
+    # UNC LocalPath means a roaming/redirected profile on a network share — skip.
+    Get-CimInstance -ClassName Win32_UserProfile -ErrorAction SilentlyContinue |
+        Where-Object {
+            -not $_.Special -and
+            -not $_.Loaded -and
+            -not [string]::IsNullOrWhiteSpace($_.LocalPath) -and
+            $_.LocalPath -notlike '\\*' -and
+            (Test-Path -LiteralPath $_.LocalPath)
+        }
+}
+
+function Clear-UserProfileCache {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProfilePath,
+        [Parameter(Mandatory)]
+        [string]$Username
+    )
+
+    Remove-FilesSafely -Path (Join-Path $ProfilePath 'AppData\Local\Temp') `
+        -Description "User Temp ($Username)"
+
+    Remove-FilesSafely -Path (Join-Path $ProfilePath 'AppData\Local\Microsoft\Windows\Explorer') `
+        -Description "Thumbnail cache ($Username)"
+
+    foreach ($browser in @(
+        @{ Name = 'Edge';   Base = 'AppData\Local\Microsoft\Edge\User Data' },
+        @{ Name = 'Chrome'; Base = 'AppData\Local\Google\Chrome\User Data' }
+    )) {
+        $browserBase = Join-Path $ProfilePath $browser.Base
+        if (Test-Path -LiteralPath $browserBase) {
+            Get-ChildItem -LiteralPath $browserBase -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -eq 'Default' -or $_.Name -like 'Profile *' } |
+                ForEach-Object {
+                    Remove-FilesSafely -Path (Join-Path $_.FullName 'Cache') `
+                        -Description "$($browser.Name) cache ($Username - $($_.Name))"
+                    Remove-FilesSafely -Path (Join-Path $_.FullName 'Code Cache') `
+                        -Description "$($browser.Name) code cache ($Username - $($_.Name))"
+                }
+        }
+    }
+
+    $ffProfilesRoot = Join-Path $ProfilePath 'AppData\Local\Mozilla\Firefox\Profiles'
+    if (Test-Path -LiteralPath $ffProfilesRoot) {
+        Get-ChildItem -LiteralPath $ffProfilesRoot -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object {
+                Remove-FilesSafely -Path (Join-Path $_.FullName 'cache2') `
+                    -Description "Firefox cache ($Username - $($_.Name))"
+            }
+    }
+}
+
 function Invoke-CleanMgrSageRun {
     $volumeCachesPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches'
     if (-not (Test-Path -LiteralPath $volumeCachesPath)) {
@@ -259,7 +315,18 @@ function Invoke-Main {
         }
     }
     else {
-        Write-Output 'Skipping current-user profile caches (running as LocalSystem).'
+        Write-Output 'Cleaning profile caches for logged-off users (running as LocalSystem)...'
+        $cleanableProfiles = Get-CleanableUserProfile
+        if (($cleanableProfiles | Measure-Object).Count -eq 0) {
+            Write-Output '  No cleanable profiles found (all users logged on, or no local user profiles present).'
+        }
+        else {
+            foreach ($userProfile in $cleanableProfiles) {
+                $username = Split-Path $userProfile.LocalPath -Leaf
+                Write-Output "  Cleaning profile: $username"
+                Clear-UserProfileCache -ProfilePath $userProfile.LocalPath -Username $username
+            }
+        }
     }
 
     if ($isAdmin) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two issues when running via RMM as LocalSystem:

1. `cleanmgr /sagerun` hung permanently — `$isAdmin` is `$true` for LocalSystem, so the guard didn't exclude it. `cleanmgr.exe` requires an interactive desktop session; under LocalSystem its cleanup handlers block indefinitely.
2. Profile cache cleanup was entirely skipped with a "Skipping" message, leaving temp files and browser caches for all local user accounts untouched.

## Changes

**Fix cleanmgr hang (`Invoke-Main`, `Invoke-CleanMgrSageRun`)**
- Guard changed from `if ($isAdmin)` to `if ($isAdmin -and -not $isSystem)` so cleanmgr is skipped entirely under LocalSystem.
- `Start-Process -Wait` replaced with `$proc.WaitForExit(300000)` + `$proc.Kill()` fallback — 5-minute ceiling prevents hang during interactive admin runs.

**Multi-profile cache cleanup (`Get-CleanableUserProfile`, `Clear-UserProfileCache`)**
- `Get-CleanableUserProfile` enumerates profiles via `Get-CimInstance Win32_UserProfile`, filtering out: service/system accounts (`Special = $true`), currently logged-on users (`Loaded = $true`), and roaming/network profiles (UNC `LocalPath`).
- `Clear-UserProfileCache` cleans per profile: `AppData\Local\Temp`, thumbnail cache, Edge/Chrome (Default + all named `Profile *` subdirectories), and Firefox `cache2` directories.
- The former "Skipping profile caches" `else`-branch is replaced with the enumeration loop.

## Testing

- ✅ Syntax check: `ParseFile` reports no errors
- ✅ PSScriptAnalyzer: no new warnings introduced (only pre-existing warnings remain)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15a14415-f45a-4324-88c2-fadbd2ffe48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15a14415-f45a-4324-88c2-fadbd2ffe48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

